### PR TITLE
Leap Motion Icon support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "elevr4"]
     path = content/elevr4
-    url = git@github.com:MozVR/elevr4.git
+    url = https://github.com/MozVR/elevr4.git
 
 [submodule "polarsea"]
     path = content/polar
-    url = git@github.com:MozVR/polarsea.git
+    url = https://github.com/MozVR/polarsea.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,7 @@
+[submodule "elevr4"]
+    path = content/elevr4
+    url = git@github.com:MozVR/elevr4.git
+
+[submodule "polarsea"]
+    path = content/polar
+    url = git@github.com:MozVR/polarsea.git

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -182,17 +182,13 @@
 				VRClientFocus = false;
 				console.log('construct unfocus');
 				updateCursorState();
-			}
+			};
 
 			VRClient.onFocus = function() {
 				VRClientFocus = true;
 				console.log('construct focus');
 				updateCursorState();
-			}
-
-//			var light = new THREE.DirectionalLight( 0xffffff, 0.15 );
-//			light.position.set( 100, 110, 150 );
-//			scene.add( light );
+			};
 
 			// Announce to Javris that everything is ready to go and we can reveal content.
 			setTimeout(function() {
@@ -251,8 +247,6 @@
 			});
 
 			Leap.loopController.use('transform', {
-//					scale: 0.001,
-//					position: new THREE.Vector3(0,-0.3,-0.35),
 					vr: true,
 					effectiveParent: this.camera
 				})

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -95,6 +95,11 @@
 		var iconsArray = [];
 		var userHeight = -1.65;
 
+		// requirements for cursor.
+		VRClientFocus = false; // todo - make focus fire on load.
+		VRClientIsVR = false;
+		handsInFrame = false;
+
 
 		function init() {
 
@@ -113,7 +118,7 @@
 			cursor.ready.then(function() {
 				scene.add(cursor.layout);
 				cursor.init(renderer.domElement, camera, scene);
-				cursor.enable();
+				updateCursorState();
 			});
 
 			setRenderMode(VRClient.renderModes.mono);
@@ -122,6 +127,7 @@
 
 			window.addEventListener( 'resize', onWindowResize, false );
 
+
 			function setRenderMode(mode) {
 				var modes = VRClient.renderModes;
 				if (mode == modes.mono) {
@@ -129,19 +135,23 @@
 					effect = renderer;
 					cursor.setMode('mono');
 					cursor.hide();
+					VRClientIsVR = false;
+					updateCursorState();
 
 				} else if (mode == modes.stereo) {
 					// controls = new THREE.DeviceOrientationControls( camera );
 					controls = null;
 					effect = new THREE.StereoEffect( renderer );
 					//cursor.setMode('centered');
-					cursor.disable();
-
+					VRClientIsVR = false;
+					updateCursorState();
 				} else if (mode == modes.vr) {
+					VRClientIsVR = true;
 					controls = new THREE.VRControls( camera );
 					effect = new THREE.VREffect( renderer );
 					cursor.setMode('centered');
 					cursor.show();
+					updateCursorState();
 				}
 
 				effect.setSize( window.innerWidth, window.innerHeight );
@@ -155,11 +165,15 @@
 			}
 
 			VRClient.onBlur = function() {
-				cursor.disable();
+				VRClientFocus = false;
+				console.log('construct unfocus');
+				updateCursorState();
 			}
 
 			VRClient.onFocus = function() {
-				cursor.enable();
+				VRClientFocus = true;
+				console.log('construct focus');
+				updateCursorState();
 			}
 
 			var light = new THREE.DirectionalLight( 0xffffff, 0.15 );
@@ -190,7 +204,27 @@
 					arm: true
 				})
 				.use('proximity');
+
+			// only show the cursor when no hands in frame.
+			Leap.loopController.on('frame', function(frame){
+
+				var newHandsInFrame = (frame.hands.length > 0);
+				if (newHandsInFrame != handsInFrame){
+					handsInFrame = newHandsInFrame;
+					updateCursorState();
+				}
+
+			});
+
 		}
+
+		updateCursorState = function(){
+			if (VRClientFocus && VRClientIsVR && !handsInFrame){
+				cursor.enable()
+			}else {
+				cursor.disable();
+			}
+		};
 
 		// bend function
 

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -304,6 +304,7 @@
 		/* scale things down to put them within reach */
 //		var masterScale = 0.55; // Desktop mode
 		var masterScale = 0.15; // VR Mode
+//		var masterScale = 1; // No Leap
 
 
 		function makeSky() {
@@ -496,8 +497,9 @@
 			var segmentsX = 20;
 			var segmentsY = 1;
 			var depth = 4 * masterScale;
-			var offsetY = 1;
+			var offsetY = 1 * masterScale;
 
+			// Adds the text description, but not the icon
 			function makeSechelt() {
 
 				var w = 58 * scale;
@@ -540,7 +542,7 @@
 				group.add( mesh );
 				group.add( highlight );
 
-				group.position.set(-depth-2, offsetY, -depth);
+				group.position.set(-depth- (2 * masterScale), offsetY, -depth);
 				group.rotation.set( 0, 60 * Math.PI / 180, 0 );
 				bend(group, depth);
 				mesh.renderDepth = 2;
@@ -591,7 +593,7 @@
 				group.add( mesh );
 				group.add( highlight );
 
-				group.position.set(1, offsetY, -depth - (3 * masterScale) );
+				group.position.set(1 * masterScale, offsetY, -depth - (3 * masterScale) );
 				bend(group, depth);
 				mesh.renderDepth = 2;
 				highlight.renderDepth = 2;
@@ -644,7 +646,7 @@
 				group.add( mesh );
 				group.add( highlight );
 
-				group.position.set(depth + 1, offsetY, -depth);
+				group.position.set(depth + (1 * masterScale), offsetY, -depth);
 				group.rotation.set( 0, -60 * Math.PI / 180, 0 );
 				bend(group, depth);
 				mesh.renderDepth = 2;

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -280,7 +280,6 @@
 			Leap.loopController.on('deviceFrame', function(){
 				if (this.connection.focusedState) return;
 
-				console.log('dropping out of focus device frame');
 				this.clear();
 			});
 		}

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -1242,7 +1242,7 @@
 			var newLastRenderTime = performance.now();
 			var elasped = newLastRenderTime - lastRenderTime;
 			if ( elasped > 25 ){
-				console.log('long elapsed time', elasped);
+//				console.log('long elapsed time', elasped);
 			}
 			window.lastRenderTime = newLastRenderTime;
 

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -75,13 +75,13 @@
 				url: 'http://mozvr.github.io/infodive',
 				popup: 'images/popup-infodive-1.png'
 			},
-			pano: {
+			"txt-panos-1": {
 				url: 'http://mozvr.github.io/panorama-viewer'
 			},
-			leap: {
+			"txt-leap-2": {
 				"url": "content/leap"
 			},
-			elevr4: {
+			"txt-elevr-1": {
 				"url": "http://mozvr.com/content/elevr4"
 			}
 
@@ -689,31 +689,23 @@
 			// Sets the rotation to face the origin.
 			// In z radians from <0,0,-1>
 			// This would be more nicely moved in to an instance method on object3d
-			positionRadially = function(output, radius, angle, height){
+			positionRadially = function(object, radius, angle, height){
 
-				output.position.set(
+				object.position.set(
 					 radius * Math.sin(angle),
 					height,
 					-radius * Math.cos(angle)
 				);
 
-				output.lookAt(
+				object.lookAt(
 					new THREE.Vector3(0,height,0)
 				);
 
+				bend(object, tileRadius);
+
 			};
 
-			var TO_RAD = Math.PI / 180;
-			var tileRadius = 0.377;
-			var tileBaseAngle = 110; // It would be better to Object-Orient this with a parent element, but.. not right now.
-			var tileAngleIncrement = 40;
-			var tileHeight = offsetY - (1.2 * masterScale);
-
-			function makePanos() {
-
-				var w = 34 * 0.07 * masterScale * tileScale;
-				var h = 67.25 * 0.07 * masterScale * tileScale;
-				var d = 1 * scale * masterScale * tileScale;
+			createTile = function(name,w,d,h,angle){
 
 				// hit area
 				var group = new THREE.Mesh(
@@ -724,26 +716,26 @@
 				// label
 				var imageMesh = new THREE.Mesh(
 					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
-					new THREE.MeshBasicMaterial( { transparent: true, opacity: 1, map: THREE.ImageUtils.loadTexture( "images/txt-panos-1.png" ) } )
+					new THREE.MeshBasicMaterial( { transparent: true, opacity: 1, map: THREE.ImageUtils.loadTexture( "images/" + name + ".png" ) } )
 				);
-				imageMesh.name = "txt-panos-1";
+				imageMesh.name = name;
+				imageMesh.receiveShadow = true;
 
 				var button = new PushButton(
 					new InteractablePlane(
-						imageMesh, Leap.loopController, {moveX: false, moveY: false}
+						imageMesh, Leap.loopController, {moveX: false, moveY: false, locking: false}
 					)
 				);
 
-				// highlight
 				var highlight = new THREE.Mesh(
 					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
 					new THREE.MeshBasicMaterial( { transparent: true, opacity: 0, color: 0x73C9EB } )
 				);
-				highlight.name = "highlight-txt-panos-1";
+				highlight.name = "highlight-" + name;
 
 				// events
 				group.addEventListener( 'click', function() {
-					VRClient.load( icons.pano.url );
+					VRClient.load( icons[name].url );
 				});
 
 				group.addEventListener( 'mouseover', function( e ) {
@@ -761,12 +753,27 @@
 				imageMesh.add( highlight ); // move with the button mesh
 				group.add( imageMesh );
 
-				positionRadially(group, tileRadius,  tileBaseAngle * TO_RAD, tileHeight );
-				bend(group, tileRadius);
+				positionRadially(group, tileRadius,  angle * TO_RAD, tileHeight );
 				imageMesh.renderDepth = 2;
 				highlight.renderDepth = 2;
 
-				return group;
+				return group
+			}
+
+			var TO_RAD = Math.PI / 180;
+			var tileRadius = 0.377;
+			var tileBaseAngle = 110; // It would be better to Object-Orient this with a parent element, but.. not right now.
+			var tileAngleIncrement = 40;
+			var tileHeight = offsetY - (1.2 * masterScale);
+
+			function makePanos() {
+
+				var w = 34 * 0.07 * masterScale * tileScale;
+				var h = 67.25 * 0.07 * masterScale * tileScale;
+				var d = 1 * scale * masterScale * tileScale;
+
+				return createTile("txt-panos-1", w,d,h, tileBaseAngle)
+
 			};
 
 
@@ -776,50 +783,8 @@
 				var h = 67.25 * 0.07 * masterScale * tileScale;
 				var d = 1 * scale * masterScale * tileScale;
 
-				// hit area
-				var group = new THREE.Mesh(
-					new THREE.BoxGeometry( w, h, d, 1, 1 ),
-					new THREE.MeshBasicMaterial({ color: 0xffffff, transparent:true, opacity: 0, depthTest: false})
-				);
+				return createTile("txt-leap-2", w,d,h, tileBaseAngle + tileAngleIncrement)
 
-				// label
-				var mesh = new THREE.Mesh(
-					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
-					new THREE.MeshBasicMaterial( { transparent: true, opacity: 1, map: THREE.ImageUtils.loadTexture( "images/txt-leap-2.png" ) } )
-				);
-
-				// highlight
-				var highlight = new THREE.Mesh(
-					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
-					new THREE.MeshBasicMaterial( { transparent: true, opacity: 0, color: 0x73C9EB } )
-				);
-
-				// events
-				group.addEventListener( 'click', function() {
-					VRClient.load( icons.leap.url );
-				});
-
-				group.addEventListener( 'mouseover', function( e ) {
-					new TWEEN.Tween( highlight.material )
-						.to( { opacity: 0.25 }, 250 )
-						.start();
-				});
-
-				group.addEventListener( 'mouseout', function( e ) {
-					new TWEEN.Tween( highlight.material )
-						.to( { opacity: 0 }, 250 )
-						.start();
-				});
-
-				group.add( mesh );
-				group.add( highlight );
-
-				positionRadially(group, tileRadius,  (tileBaseAngle + tileAngleIncrement) * TO_RAD, tileHeight );
-				bend(group, tileRadius);
-				mesh.renderDepth = 2;
-				highlight.renderDepth = 2;
-
-				return group;
 			};
 
 
@@ -829,54 +794,7 @@
 				var h = 67.25 * 0.07 * masterScale * tileScale;
 				var d = 1 * scale * masterScale * tileScale;
 
-				// hit area
-				var group = new THREE.Mesh(
-					new THREE.BoxGeometry( w, h, d, 1, 1 ),
-					new THREE.MeshBasicMaterial({ color: 0xffffff, transparent:true, opacity: 0, depthTest: false})
-				);
-
-				// label
-				var mesh = new THREE.Mesh(
-					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
-					new THREE.MeshBasicMaterial( { transparent: true, opacity: 1, map: THREE.ImageUtils.loadTexture( "images/txt-elevr-1.png" ) } )
-				);
-
-				// highlight
-				var highlight = new THREE.Mesh(
-					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
-					new THREE.MeshBasicMaterial( { transparent: true, opacity: 0, color: 0x73C9EB } )
-				);
-
-				// events
-				group.addEventListener( 'click', function() {
-					VRClient.load( icons.elevr4.url );
-				});
-
-				group.addEventListener( 'mouseover', function( e ) {
-					new TWEEN.Tween( highlight.material )
-						.to( { opacity: 0.25 }, 250 )
-						.start();
-				});
-
-				group.addEventListener( 'mouseout', function( e ) {
-					new TWEEN.Tween( highlight.material )
-						.to( { opacity: 0 }, 250 )
-						.start();
-				});
-
-				group.add( mesh );
-				group.add( highlight );
-
-				positionRadially(group, tileRadius,  (tileBaseAngle + tileAngleIncrement * 2) * TO_RAD, tileHeight );
-				bend(group, tileRadius);
-				mesh.renderDepth = 2;
-				highlight.renderDepth = 2;
-
-				// var holder = new THREE.Object3D();
-				// holder.add( group );
-				// holder.rotation.set( 0, 286 * Math.PI / 180, 0 );
-
-				return group;
+				return createTile("txt-elevr-1", w,d,h, tileBaseAngle + tileAngleIncrement * 2)
 			};
 
 

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -83,6 +83,12 @@
 			},
 			"txt-elevr-1": {
 				"url": "http://mozvr.com/content/elevr4"
+			},
+			"txt-polarsea-3": {
+				url: 'http://mozvr.com/content/polar',
+			},
+			"txt-infodive-2": {
+				url: 'http://mozvr.github.io/infodive',
 			}
 
 		}
@@ -95,6 +101,7 @@
 		var icons;
 		var iconsArray = [];
 		var userHeight = -1.65;
+		var iconAngle = 45; // degrees
 
 		// requirements for cursor.
 		// This state tracking is sort of ugly, and should be moved to inside VRClient and/or VRCursor.
@@ -535,160 +542,43 @@
 			var depth = 4 * masterScale;
 			var offsetY = 1 * masterScale;
 
+
+			var TO_RAD = Math.PI / 180;
+			var tileRadius = 0.56;
+			var tileBaseAngle = 110; // It would be better to Object-Orient this with a parent element, but.. not right now.
+			var tileAngleIncrement = 40;
+			var tileHeight = offsetY - (1.2 * masterScale);
+			var iconDescriptionRadius = tileRadius + 0.25;
+			var iconDescriptionHeight = tileHeight + 0.05;
+
 			// Adds the text description, but not the icon
 			function makeSechelt() {
 
-				var w = 58 * scale;
-				var h = 30 * scale;
-				var d = 1 * scale;
+				var w = 58 * 0.07 * masterScale * tileScale;
+				var h = 30 * 0.07 * masterScale * tileScale;
+				var d = 1 * scale * 0.07 * masterScale * tileScale;
 
-				// hit area
-				var group = new THREE.Mesh(
-					new THREE.BoxGeometry( w, h, d, 1, 1 ),
-					new THREE.MeshBasicMaterial({ color: 0xffffff, transparent:true, opacity: 0, depthTest: false})
-				);
-
-				var mesh = new THREE.Mesh(
-					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
-					new THREE.MeshBasicMaterial( { transparent: true, opacity: 1, map: THREE.ImageUtils.loadTexture( "images/txt-sechelt-1.png" ) } )
-				);
-
-				var highlight = new THREE.Mesh(
-					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
-					new THREE.MeshBasicMaterial( { transparent: true, opacity: 0, color: 0x73C9EB } )
-				);
-
-				// events
-				group.addEventListener( 'click', function() {
-					VRClient.load( icons.sechelt.url );
-				});
-
-				group.addEventListener( 'mouseover', function( e ) {
-					new TWEEN.Tween( highlight.material )
-						.to( { opacity: 0.25 }, 250 )
-						.start();
-				});
-
-				group.addEventListener( 'mouseout', function( e ) {
-					new TWEEN.Tween( highlight.material )
-						.to( { opacity: 0 }, 250 )
-						.start();
-				});
-
-				group.add( mesh );
-				group.add( highlight );
-
-				group.position.set(-depth- (2 * masterScale), offsetY, -depth);
-				group.rotation.set( 0, 60 * Math.PI / 180, 0 );
-				bend(group, depth);
-				mesh.renderDepth = 2;
-				highlight.renderDepth = 2;
-
-				return group;
+				return createTile("txt-sechelt-1", w,d,h, -iconAngle - 12, iconDescriptionRadius, iconDescriptionHeight )
 			}
 
 
 			function makePolar() {
 
-				var w = 63 * scale;
-				var h = 30 * scale;
-				var d = 1 * scale;
+				var w = 63 * 0.07 * masterScale * tileScale;
+				var h = 30 * 0.07 * masterScale * tileScale;
+				var d = 1 * scale * masterScale * tileScale;
 
-				// hit area
-				var group = new THREE.Mesh(
-					new THREE.BoxGeometry( w, h, d, 1, 1 ),
-					new THREE.MeshBasicMaterial({ color: 0xffffff, transparent:true, opacity: 0, depthTest: false})
-				);
-
-				var mesh = new THREE.Mesh(
-					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
-					new THREE.MeshBasicMaterial( { transparent: true, opacity: 1, map: THREE.ImageUtils.loadTexture( "images/txt-polarsea-3.png" ) } )
-				);
-				var highlight = new THREE.Mesh(
-					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
-					new THREE.MeshBasicMaterial( { transparent: true, opacity: 0, color: 0x73C9EB } )
-				);
-
-				// events
-				group.addEventListener( 'click', function() {
-					VRClient.load( icons.polar.url );
-				});
-
-				group.addEventListener( 'mouseover', function( e ) {
-					new TWEEN.Tween( highlight.material )
-						.to( { opacity: 0.25 }, 250 )
-						.start();
-				});
-
-				group.addEventListener( 'mouseout', function( e ) {
-					new TWEEN.Tween( highlight.material )
-						.to( { opacity: 0 }, 250 )
-						.start();
-				});
-
-				group.add( mesh );
-				group.add( highlight );
-
-				group.position.set(1 * masterScale, offsetY, -depth - (3 * masterScale) );
-				bend(group, depth);
-				mesh.renderDepth = 2;
-				highlight.renderDepth = 2;
-
-				return group;
+				return createTile("txt-polarsea-3", w,d,h, 0, iconDescriptionRadius, iconDescriptionHeight )
 			}
 
 
 			function makeInfo() {
 
-				var w = 59 * scale;
-				var h = 30 * scale;
-				var d = 1 * scale;
+				var w = 59 * 0.07 * masterScale * tileScale;
+				var h = 30 * 0.07 * masterScale * tileScale;
+				var d = 1 * scale  * masterScale * tileScale;
 
-				// hit area
-				var group = new THREE.Mesh(
-					new THREE.BoxGeometry( w, h, d, 1, 1 ),
-					new THREE.MeshBasicMaterial({ color: 0xffffff, transparent:true, opacity: 0, depthTest: false})
-				);
-
-				// label
-				var mesh = new THREE.Mesh(
-					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
-					new THREE.MeshBasicMaterial( { transparent: true, opacity: 1, map: THREE.ImageUtils.loadTexture( "images/txt-infodive-2.png" ) } )
-				);
-
-				// highlight
-				var highlight = new THREE.Mesh(
-					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
-					new THREE.MeshBasicMaterial( { transparent: true, opacity: 0, color: 0x73C9EB } )
-				);
-
-				// events
-				group.addEventListener( 'click', function() {
-					VRClient.load( icons.dive.url );
-				});
-
-				group.addEventListener( 'mouseover', function( e ) {
-					new TWEEN.Tween( highlight.material )
-						.to( { opacity: 0.25 }, 250 )
-						.start();
-				});
-
-				group.addEventListener( 'mouseout', function( e ) {
-					new TWEEN.Tween( highlight.material )
-						.to( { opacity: 0 }, 250 )
-						.start();
-				});
-
-				group.add( mesh );
-				group.add( highlight );
-
-				group.position.set(depth + (1 * masterScale), offsetY, -depth);
-				group.rotation.set( 0, -60 * Math.PI / 180, 0 );
-				bend(group, depth);
-				mesh.renderDepth = 2;
-				highlight.renderDepth = 2;
-
-				return group;
+				return createTile("txt-infodive-2", w,d,h, iconAngle + 12, iconDescriptionRadius, iconDescriptionHeight )
 			};
 
 			// Sets position at radius and angle
@@ -709,12 +599,14 @@
 
 			};
 
-			createTile = function(name,w,d,h,angle){
+			createTile = function(name,w,d,h,angle,radius,height){
+				radius || (radius = tileRadius);
+				height || (height = tileHeight);
 
 				// hit area
 				var group = new THREE.Mesh(
 					new THREE.BoxGeometry( w, h, d, 1, 1 ),
-					new THREE.MeshBasicMaterial({ color: 0xffffff, transparent:true, opacity: 0, depthTest: false})
+					new THREE.MeshBasicMaterial({ color: 0xffffff, transparent:true, opacity: 0, depthTest: false, side: THREE.DoubleSide})
 				);
 
 				var imageMesh = new THREE.Mesh(
@@ -776,18 +668,13 @@
 				imageMesh.add( highlight ); // move with the button mesh
 				group.add( imageMesh );
 
-				positionRadially(group, tileRadius,  angle * TO_RAD, tileHeight );
+				positionRadially(group, radius,  angle * TO_RAD, height );
+				bend(group, tileRadius);
 				imageMesh.renderDepth = 2;
 				highlight.renderDepth = 2;
 
 				return group
 			}
-
-			var TO_RAD = Math.PI / 180;
-			var tileRadius = 0.6;
-			var tileBaseAngle = 110; // It would be better to Object-Orient this with a parent element, but.. not right now.
-			var tileAngleIncrement = 40;
-			var tileHeight = offsetY - (1.2 * masterScale);
 
 			function makePanos() {
 
@@ -821,9 +708,12 @@
 			};
 
 
+			// descriptions
 			scene.add( makeSechelt() );
 			scene.add( makePolar() );
 			scene.add( makeInfo() );
+
+			// tiles
 			scene.add( makePanos() );
 			scene.add( makeLeap() );
 			scene.add( makeEleVR() );
@@ -1048,7 +938,7 @@
 				// create parent holder object
 				var holder = makeIconHolder( icons.sechelt, object );
 				holder.scale.set( iconBaseScale, iconBaseScale, iconBaseScale );
-				positionRadially(holder, iconRadius, -45, iconBasePos.y);
+				positionRadially(holder, iconRadius, -iconAngle, iconBasePos.y);
 
 				// store original position for later use.
 				holder.userData.position = holder.position.clone();
@@ -1086,7 +976,7 @@
 				// create parent holder object
 				var holder = makeIconHolder( icons.dive, object );
 				holder.scale.set( iconBaseScale, iconBaseScale, iconBaseScale );
-				positionRadially(holder, iconRadius, 45, iconBasePos.y);
+				positionRadially(holder, iconRadius, iconAngle, iconBasePos.y);
 
 				// store original position for later use.
 				holder.userData.position = holder.position.clone();

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -222,6 +222,19 @@
 			camera.add(handLight);
 
 
+			Leap.Controller.prototype.clear = function(){
+				var frameData = this.lastConnectionFrame.data;
+
+				if (!frameData) return;
+
+				frameData.hands      = [];
+				frameData.fingers    = [];
+				frameData.pointables = [];
+				frameData.tools      = [];
+
+				this.lastConnectionFrame = new Leap.Frame(frameData);
+			};
+
 
 			Leap.loop();
 
@@ -250,6 +263,7 @@
 				.use('proximity');
 
 
+
 			// only show the cursor when no hands in frame.
 			Leap.loopController.on('streamingStarted', updateCursorState);
 			Leap.loopController.on('streamingStopped', updateCursorState);
@@ -263,7 +277,19 @@
 //				console.log('mm', e.clientX, e.clientY); // firefox
 //			});
 
+			// Hide the hand when focus is lost.
+			window.addEventListener('blur', function(){
+				Leap.loopController.clear();
+			});
+
+			Leap.loopController.on('deviceFrame', function(){
+				if (this.connection.focusedState) return;
+
+				console.log('dropping out of focus device frame');
+				this.clear();
+			});
 		}
+
 
 
 		updateCursorState = function(){

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -237,21 +237,23 @@
 
 
 			// only show the cursor when no hands in frame.
-			Leap.loopController.on('frame', function(frame){
+			Leap.loopController.on('streamingStarted', updateCursorState);
+			Leap.loopController.on('streamingStopped', updateCursorState);
 
-				var newHandsInFrame = (frame.hands.length > 0);
-				if (newHandsInFrame != handsInFrame){
-					handsInFrame = newHandsInFrame;
-					updateCursorState();
-				}
-
-			});
+			// Todo - check if mouse is being moved, and show cursor for 1s..
+			// doesn't seem to be passed through to iframe
+			// not because the iframe wouldn't get them, but because there are layers of transparent divs above.
+			// Maybe we need a shim which would pipe these events through, to do it right.
+//			document.addEventListener("mousemove", function(e){
+//				console.log('mm', e.x, e.y); // chrome
+//				console.log('mm', e.clientX, e.clientY); // firefox
+//			});
 
 		}
 
 
 		updateCursorState = function(){
-			if (VRClientFocus && VRClientIsVR && !handsInFrame){
+			if (VRClientFocus && VRClientIsVR && !Leap.loopController.streaming() ){
 				cursor.enable()
 			}else {
 				cursor.disable();

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -857,7 +857,12 @@
 			holder.add(dolly);
 
 			var button = new PushButton(
-				new InteractablePlane(buttonMesh, Leap.loopController, {moveX: false, moveY: false}),
+				new InteractablePlane(buttonMesh, Leap.loopController,
+						{
+							moveX: false,
+							moveY: false,
+							hoverBounds: [0, 30] // different units.
+						}),
 				{
 					locking: false,
 					longThrow: -35
@@ -926,7 +931,7 @@
 					.to( { opacity: 1 }, 100 )
 					.start();
 
-			})
+			});
 
 			holder.addEventListener('mouseout', function(e) {
 
@@ -946,7 +951,7 @@
 				new TWEEN.Tween( mesh.material )
 					.to( { opacity: 0 }, 100 )
 					.start();
-			})
+			});
 
 			holder.scale.multiplyScalar(iconBaseScale);
 
@@ -964,6 +969,36 @@
 			holder.userData.shadow = shadow;
 
 
+			var ring = new THREE.Mesh(
+				new THREE.LatheGeometry(
+						[new THREE.Vector3(0,79.5,0), new THREE.Vector3(0,88,0) ],
+						48
+				),
+				new THREE.MeshBasicMaterial( { color: 0x000000, transparent: true, wireframe: false, opacity: 0 } )
+			);
+
+			ring.rotation.set( Math.PI / 2, 0, 0 );
+			ring.position.copy(shadow.position);
+			ring.position.y -= 1;
+			holder.userData.ring = ring;
+			holder.add(ring);
+
+			// Note: It may be interesting to replace this with a fade based on position instead of time
+			// Would have to be distance from position of collider, to give gradual effect in all three dimensions.
+			var fadeSpeed = 200;
+			ring.userData.tweenIn  = new TWEEN.Tween( ring.material ).to( { opacity: shadow.material.opacity }, fadeSpeed );
+			ring.userData.tweenOut = new TWEEN.Tween( ring.material ).to( { opacity: 0 }, fadeSpeed );
+			button.plane.hover(
+				function(){
+					ring.userData.tweenOut.stop();
+					ring.userData.tweenIn.start();
+				},
+				function(){
+					ring.userData.tweenIn.stop();
+					ring.userData.tweenOut.start();
+				}
+			);
+
 			return holder;
 
 		}
@@ -974,7 +1009,7 @@
 				new THREE.CircleGeometry( 40, 60, 0, Math.PI * 2 ),
 				new THREE.MeshBasicMaterial( { color: 0x000000, wireframe: false, transparent: true, opacity: 0.15 } )
 			);
-			shadow.rotation.set( 0 - Math.PI / 2, 0, 0 )
+			shadow.rotation.set( 0 - Math.PI / 2, 0, 0 );
 
 			return shadow;
 		}

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -206,6 +206,8 @@
 			handLight.shadowCameraNear = 0.01;
 			handLight.shadowCameraFar = 3;
 			handLight.shadowDarkness = 0.8;
+			handLight.shadowMapWidth = 1024; // default is 512
+			handLight.shadowMapHeight = 1024; // default is 512
 
 			handLight.position.set(0,1,1);
 			handLight.target.position.set(0,0,-1);

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -254,7 +254,8 @@
 				.use('boneHand', {
 					scene: this.scene,
 					arm: true,
-					opacity: 1
+					opacity: 1,
+					jointColor: (new THREE.Color).setHex(0x7984B5)
 				})
 				.use('proximity');
 

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -36,6 +36,7 @@
 	<script src="//js.leapmotion.com/leap-0.6.4.js"></script>
 	<script src="../../js/vendor/leap-plugins-0.1.11pre.js"></script>
 	<script src="../../js/vendor/leap-widgets-0.1.0.js"></script>
+	<!--<script src="../../js/vendor/OrbitControls.js"></script>-->
 
 	<!-- This is a library that allows this application to communicate with the main JAVRIS application host -->
 	<script src="../../js/vrclient.js"></script>
@@ -124,6 +125,7 @@
 			camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.01, 10000 );
 			scene.add(camera); // Lights are attached and must be in scene.
 
+			if (THREE.OrbitControls) window.orbitControls = new THREE.OrbitControls( camera );
 
 			cursor = new VRCursor();
 
@@ -454,7 +456,7 @@
 
 			makeSky();
 	  	scene.fog = new THREE.Fog( 0x6ab5db, 30, 300 );
-			camera.position.set( 0, 0, 0 );
+			if (THREE.OrbitControls) camera.position.set( 0, 0, -0.1 );
 			makeParticles();
 			populateIcons();
 
@@ -1180,6 +1182,8 @@
 
 				particle.setRotationFromQuaternion( quat );
 			}
+
+			if (THREE.OrbitControls) orbitControls.update();
 
 			requestAnimationFrame( animate );
 			render();

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -199,6 +199,7 @@
 
 
 			var handLight = new THREE.SpotLight(0xffffff, 0.25);
+			// Note, this causes WebGL errors with r69: https://github.com/mrdoob/three.js/issues/5293
 			handLight.castShadow = true;
 			handLight.shadowCameraVisible = false;
 			handLight.shadowCameraNear = 0.01;

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -763,7 +763,7 @@
 			}
 
 			var TO_RAD = Math.PI / 180;
-			var tileRadius = 0.377;
+			var tileRadius = 0.6;
 			var tileBaseAngle = 110; // It would be better to Object-Orient this with a parent element, but.. not right now.
 			var tileAngleIncrement = 40;
 			var tileHeight = offsetY - (1.2 * masterScale);

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -707,8 +707,6 @@
 					new THREE.Vector3(0,height,0)
 				);
 
-				bend(object, tileRadius);
-
 			};
 
 			createTile = function(name,w,d,h,angle){
@@ -1035,6 +1033,8 @@
 
 		function populateIcons() {
 
+			var iconRadius = 0.56; // same as tileRadius
+
 			var loader = new THREE.ObjectLoader();
 			var iconBasePos = {// base positioning of icons position.
 				x: 0,
@@ -1045,19 +1045,13 @@
 
 			loader.load( icons.sechelt.model, function ( object ) {
 
-				// relative object positioning to iconBasePos.
-				var x = iconBasePos.x - (2.25 * masterScale),
-					  y = iconBasePos.y + (0.2 * masterScale),
-					  z = iconBasePos.z + (2.5 * masterScale);
-
 				// create parent holder object
 				var holder = makeIconHolder( icons.sechelt, object );
 				holder.scale.set( iconBaseScale, iconBaseScale, iconBaseScale );
-				holder.position.set( x, y, z);
-				holder.rotation.set( 0, 130 * (Math.PI/180), 0 );
+				positionRadially(holder, iconRadius, -45, iconBasePos.y);
 
 				// store original position for later use.
-				holder.userData.position = new THREE.Vector3(x, y, z);
+				holder.userData.position = holder.position.clone();
 
 				// create dropshadow
 				var shadow = makeIconShadow();
@@ -1070,19 +1064,13 @@
 
 			loader.load( icons.polar.model, function ( object ) {
 
-				// relative object positioning to iconBasePos.
-				var x = iconBasePos.x + (0   * masterScale),
-				   	y = iconBasePos.y + (0   * masterScale),
-					  z = iconBasePos.z - (0.5 * masterScale);
-
 				// create parent holder object
 				var holder = makeIconHolder( icons.polar, object );
 				holder.scale.set( iconBaseScale, iconBaseScale, iconBaseScale );
-				holder.position.set( x, y, z);
-				holder.rotation.set( 0, 80 * (Math.PI/180), 0 );
+				positionRadially(holder, iconRadius, 0, iconBasePos.y);
 
 				// store original position for later use.
-				holder.userData.position = new THREE.Vector3(x, y, z);
+				holder.userData.position = holder.position.clone();
 
 				// create dropshadow
 				var shadow = makeIconShadow();
@@ -1095,19 +1083,13 @@
 
 			loader.load( icons.dive.model, function ( object ) {
 
-				// relative object positioning to iconBasePos.
-				var x = iconBasePos.x + (2.25 * masterScale),
-					  y = iconBasePos.y + (0.2 * masterScale),
-					  z = iconBasePos.z + (2.5 * masterScale);
-
 				// create parent holder object
 				var holder = makeIconHolder( icons.dive, object );
 				holder.scale.set( iconBaseScale, iconBaseScale, iconBaseScale );
-				holder.position.set( x, y, z );
-				holder.rotation.set( 0, 35 * (Math.PI/180), 0 );
+				positionRadially(holder, iconRadius, 45, iconBasePos.y);
 
 				// store original position for later use.
-				holder.userData.position = new THREE.Vector3(x, y, z);
+				holder.userData.position = holder.position.clone();
 
 				// create dropshadow
 				var shadow = makeIconShadow();

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -41,6 +41,7 @@
 	<script src="../../js/vrclient.js"></script>
 	<script src="../../js/vrcursor.js"></script>
 
+
 	<script>
 
 
@@ -97,7 +98,7 @@
 
 		// requirements for cursor.
 		// This state tracking is sort of ugly, and should be moved to inside VRClient and/or VRCursor.
-		VRClientFocus = false; // todo - make focus fire on load.
+		VRClientFocus = false;
 		VRClientIsVR = false;
 		handsInFrame = false;
 
@@ -106,6 +107,8 @@
 
 			renderer = new THREE.WebGLRenderer( { antialias: true } );
 			renderer.autoClear = false;
+			renderer.shadowMapEnabled = true;
+	  	renderer.shadowMapType = THREE.PCFSoftShadowMap;
 			renderer.setClearColor( 0x000000 );
 
 			document.body.appendChild( renderer.domElement );
@@ -189,12 +192,38 @@
 
 
 
-			var handLight = new THREE.PointLight(0xffffff, 1, 1);
-			handLight.position.setY(0.3);
-			this.scene.add(handLight);
+			var handLight = new THREE.SpotLight(0xffffff, 0.25);
+			handLight.castShadow = true;
+			handLight.shadowCameraVisible = true;
+			handLight.shadowCameraNear = 0.01;
+			handLight.shadowCameraFar = 3;
+			handLight.shadowDarkness = 0.8;
 
-			Leap.loop()
-				.use('transform', {
+			handLight.target.position.set(0,0,-1);
+			scene.add(handLight.target);
+
+			var dolly = new THREE.Object3D;
+			dolly.position.set(0,0.2,0.8);
+
+			scene.add(dolly);
+			dolly.add(handLight);
+
+
+			Leap.loop();
+
+			// Add a certain default lightness, even in low-light situations
+			Leap.loopController.on('handMeshCreated', function(handMesh){
+
+				handMesh.traverse(function(mesh){
+					// mesh is a joint or a bone
+					if (mesh.material){
+						mesh.material.emissive.copy(mesh.material.color).multiplyScalar(0.75);
+					}
+				})
+
+			});
+
+			Leap.loopController.use('transform', {
 //					scale: 0.001,
 //					position: new THREE.Vector3(0,-0.3,-0.35),
 					vr: true,
@@ -205,6 +234,7 @@
 					arm: true
 				})
 				.use('proximity');
+
 
 			// only show the cursor when no hands in frame.
 			Leap.loopController.on('frame', function(frame){
@@ -218,6 +248,7 @@
 			});
 
 		}
+
 
 		updateCursorState = function(){
 			if (VRClientFocus && VRClientIsVR && !handsInFrame){
@@ -951,6 +982,11 @@
 			buttonMesh.add(iconObject);
 
 
+			iconObject.traverse(function(child){
+				child.receiveShadow = true
+			});
+
+
 			// popup
 
 			var popup = new THREE.Object3D();
@@ -1104,9 +1140,8 @@
 				// create parent holder object
 				var holder = makeIconHolder( icons.dive, object );
 				holder.scale.set( iconBaseScale, iconBaseScale, iconBaseScale );
-				holder.position.set( x, y, z);
+				holder.position.set( x, y, z );
 				holder.rotation.set( 0, 35 * (Math.PI/180), 0 );
-				//holder.add( makeInfoDive() );
 
 				// store original position for later use.
 				holder.userData.position = new THREE.Vector3(x, y, z);

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -253,7 +253,8 @@
 				})
 				.use('boneHand', {
 					scene: this.scene,
-					arm: true
+					arm: true,
+					opacity: 1
 				})
 				.use('proximity');
 
@@ -282,6 +283,19 @@
 
 				this.clear();
 			});
+
+			Leap.loopController.on('hand', function(hand){
+
+				var handMesh = hand.data('handMesh');
+				if (!handMesh) return;
+
+				handMesh.traverse(function(mesh){
+					if (!mesh.material) return;
+					mesh.material.opacity = hand.confidence;
+				});
+
+			});
+
 		}
 
 

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -36,7 +36,7 @@
 	<script src="//js.leapmotion.com/leap-0.6.4.js"></script>
 	<script src="../../js/vendor/leap-plugins-0.1.11pre.js"></script>
 	<script src="../../js/vendor/leap-widgets-0.1.0.js"></script>
-	<!--<script src="../../js/vendor/OrbitControls.js"></script>-->
+	<script src="../../js/vendor/OrbitControls.js"></script>
 
 	<!-- This is a library that allows this application to communicate with the main JAVRIS application host -->
 	<script src="../../js/vrclient.js"></script>
@@ -590,6 +590,7 @@
 			// In z radians from <0,0,-1>
 			// This would be more nicely moved in to an instance method on object3d
 			positionRadially = function(object, radius, angle, height){
+				height || (height = group.position.y);
 
 				object.position.set(
 					 radius * Math.sin(angle),

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -719,7 +719,6 @@
 					new THREE.MeshBasicMaterial({ color: 0xffffff, transparent:true, opacity: 0, depthTest: false})
 				);
 
-				// label
 				var imageMesh = new THREE.Mesh(
 					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
 					new THREE.MeshBasicMaterial( { transparent: true, opacity: 1, map: THREE.ImageUtils.loadTexture( "images/" + name + ".png" ) } )
@@ -734,28 +733,47 @@
 					{locking: false}
 				);
 
+
 				var highlight = new THREE.Mesh(
 					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
 					new THREE.MeshBasicMaterial( { transparent: true, opacity: 0, color: 0x73C9EB } )
 				);
 				highlight.name = "highlight-" + name;
 
+				// TODO - old animate should be aborted before new animation begins.
+				animateInHighlight = function( ) {
+					new TWEEN.Tween( highlight.material )
+						.to( { opacity: 0.25 }, 250 )
+						.start();
+				};
+
+				animateOutHighlight = function( ) {
+					new TWEEN.Tween( highlight.material )
+						.to( { opacity: 0 }, 250 )
+						.start();
+				};
+
+				var hoverJump = 0.01;
+				button.plane.hoverBounds = [0, 0.25];
+				button.plane.hover( animateInHighlight, animateOutHighlight );
+				button.plane.hover(
+						function(){ button.plane.originalPosition.z += hoverJump },
+						function(){
+							// We use a tween to return, rather than the spring which took it out, as there is no back end constraint.
+							new TWEEN.Tween( button.plane.originalPosition )
+												.to( { z: button.plane.originalPosition.z - hoverJump }, 250 )
+												.start();
+						}
+				);
+
 				// events
 				group.addEventListener( 'click', function() {
 					VRClient.load( icons[name].url );
 				});
 
-				group.addEventListener( 'mouseover', function( e ) {
-					new TWEEN.Tween( highlight.material )
-						.to( { opacity: 0.25 }, 250 )
-						.start();
-				});
+				group.addEventListener( 'mouseover', animateInHighlight );
 
-				group.addEventListener( 'mouseout', function( e ) {
-					new TWEEN.Tween( highlight.material )
-						.to( { opacity: 0 }, 250 )
-						.start();
-				});
+				group.addEventListener( 'mouseout', animateOutHighlight );
 
 				imageMesh.add( highlight ); // move with the button mesh
 				group.add( imageMesh );

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -685,12 +685,35 @@
 				return group;
 			};
 
+			// Sets position at radius and angle
+			// Sets the rotation to face the origin.
+			// In z radians from <0,0,-1>
+			// This would be more nicely moved in to an instance method on object3d
+			positionRadially = function(output, radius, angle, height){
+
+				output.position.set(
+					 radius * Math.sin(angle),
+					height,
+					-radius * Math.cos(angle)
+				);
+
+				output.lookAt(
+					new THREE.Vector3(0,height,0)
+				);
+
+			};
+
+			var TO_RAD = Math.PI / 180;
+			var tileRadius = 0.377;
+			var tileBaseAngle = 110; // It would be better to Object-Orient this with a parent element, but.. not right now.
+			var tileAngleIncrement = 40;
+			var tileHeight = offsetY - (1.2 * masterScale);
 
 			function makePanos() {
 
-				var w = 34 * 0.07 * masterScale;
-				var h = 67.25 * 0.07 * masterScale;
-				var d = 1 * scale * masterScale;
+				var w = 34 * 0.07 * masterScale * tileScale;
+				var h = 67.25 * 0.07 * masterScale * tileScale;
+				var d = 1 * scale * masterScale * tileScale;
 
 				// hit area
 				var group = new THREE.Mesh(
@@ -738,9 +761,8 @@
 				imageMesh.add( highlight ); // move with the button mesh
 				group.add( imageMesh );
 
-				group.position.set(2.5 * masterScale, offsetY-(1.2 * masterScale), 0.25 * masterScale);
-				group.rotation.set( 0, -105 * Math.PI / 180, 0 );
-				bend(group, 9);
+				positionRadially(group, tileRadius,  tileBaseAngle * TO_RAD, tileHeight );
+				bend(group, tileRadius);
 				imageMesh.renderDepth = 2;
 				highlight.renderDepth = 2;
 
@@ -750,9 +772,9 @@
 
 			function makeLeap() {
 
-				var w = 34 * 0.07;
-				var h = 67.25 * 0.07;
-				var d = 1 * scale;
+				var w = 34 * 0.07 * masterScale * tileScale;
+				var h = 67.25 * 0.07 * masterScale * tileScale;
+				var d = 1 * scale * masterScale * tileScale;
 
 				// hit area
 				var group = new THREE.Mesh(
@@ -792,9 +814,8 @@
 				group.add( mesh );
 				group.add( highlight );
 
-				group.position.set(4.00, offsetY-1.2, 2.5);
-				group.rotation.set( 0, -125 * Math.PI / 180, 0 );
-				bend(group, 9);
+				positionRadially(group, tileRadius,  (tileBaseAngle + tileAngleIncrement) * TO_RAD, tileHeight );
+				bend(group, tileRadius);
 				mesh.renderDepth = 2;
 				highlight.renderDepth = 2;
 
@@ -804,9 +825,9 @@
 
 			function makeEleVR() {
 
-				var w = 34 * 0.07;
-				var h = 67.25 * 0.07;
-				var d = 1 * scale;
+				var w = 34 * 0.07 * masterScale * tileScale;
+				var h = 67.25 * 0.07 * masterScale * tileScale;
+				var d = 1 * scale * masterScale * tileScale;
 
 				// hit area
 				var group = new THREE.Mesh(
@@ -846,9 +867,8 @@
 				group.add( mesh );
 				group.add( highlight );
 
-				group.position.set(2.3, offsetY-1.2, 4.4);
-				group.rotation.set( 0, -140 * Math.PI / 180, 0 );
-				bend(group, 9);
+				positionRadially(group, tileRadius,  (tileBaseAngle + tileAngleIncrement * 2) * TO_RAD, tileHeight );
+				bend(group, tileRadius);
 				mesh.renderDepth = 2;
 				highlight.renderDepth = 2;
 

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -849,10 +849,12 @@
 
 			var button = new PushButton(
 				new InteractablePlane(buttonMesh, Leap.loopController, {moveX: false, moveY: false}),
-				{locking: false}
+				{
+					locking: false,
+					longThrow: -35
+				}
 			);
 
-			button.longThrow = -35;
 			button.on('press', function(){
 				holder.dispatchEvent({type: 'click'});
 			});

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -656,6 +656,10 @@
 						}
 				);
 
+				button.on('press', function(){
+					group.dispatchEvent({type: 'click'});
+				});
+
 				// events
 				group.addEventListener( 'click', function() {
 					VRClient.load( icons[name].url );

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -558,16 +558,16 @@
 				// hit area
 				var group = new THREE.Mesh(
 					new THREE.BoxGeometry( w, h, d, 1, 1 ),
-					new THREE.MeshBasicMaterial({ color: 0xffffff, transparent:false, opacity: 0, depthTest: false})
+					new THREE.MeshBasicMaterial({ color: 0xffffff, transparent:true, opacity: 0, depthTest: false})
 				);
 
 				var mesh = new THREE.Mesh(
 					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
-					new THREE.MeshBasicMaterial( { transparent: false, opacity: 1, map: THREE.ImageUtils.loadTexture( "images/txt-polarsea-3.png" ) } )
+					new THREE.MeshBasicMaterial( { transparent: true, opacity: 1, map: THREE.ImageUtils.loadTexture( "images/txt-polarsea-3.png" ) } )
 				);
 				var highlight = new THREE.Mesh(
 					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
-					new THREE.MeshBasicMaterial( { transparent: false, opacity: 0, color: 0x73C9EB } )
+					new THREE.MeshBasicMaterial( { transparent: true, opacity: 0, color: 0x73C9EB } )
 				);
 
 				// events
@@ -590,7 +590,7 @@
 				group.add( mesh );
 				group.add( highlight );
 
-//				group.position.set(1, offsetY, -depth - (3 * masterScale) );
+				group.position.set(1, offsetY, -depth - (3 * masterScale) );
 				bend(group, depth);
 				mesh.renderDepth = 2;
 				highlight.renderDepth = 2;

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -544,7 +544,7 @@
 
 
 			var TO_RAD = Math.PI / 180;
-			var tileRadius = 0.56;
+			var tileRadius = 0.5;
 			var tileBaseAngle = 110; // It would be better to Object-Orient this with a parent element, but.. not right now.
 			var tileAngleIncrement = 40;
 			var tileHeight = offsetY - (1.2 * masterScale);
@@ -794,7 +794,7 @@
 		/*====================== Make icons ======================*/
 
 
-		function makeIconHolder( json, iconObject ) {
+		function makeIconHolder( json, iconObject, scale ) {
 
 
 			// holder
@@ -824,7 +824,6 @@
 			);
 
 			button.longThrow = -35;
-			button.shortThrow = -20;
 			button.on('press', function(){
 				holder.dispatchEvent({type: 'click'});
 			});
@@ -904,10 +903,11 @@
 					.start();
 			})
 
+			holder.scale.multiplyScalar(scale);
+
 			return holder;
 
 		}
-
 
 		function makeIconShadow(  ){
 
@@ -936,8 +936,7 @@
 			loader.load( icons.sechelt.model, function ( object ) {
 
 				// create parent holder object
-				var holder = makeIconHolder( icons.sechelt, object );
-				holder.scale.set( iconBaseScale, iconBaseScale, iconBaseScale );
+				var holder = makeIconHolder( icons.sechelt, object, iconBaseScale );
 				positionRadially(holder, iconRadius, -iconAngle, iconBasePos.y);
 
 				// store original position for later use.
@@ -955,8 +954,7 @@
 			loader.load( icons.polar.model, function ( object ) {
 
 				// create parent holder object
-				var holder = makeIconHolder( icons.polar, object );
-				holder.scale.set( iconBaseScale, iconBaseScale, iconBaseScale );
+				var holder = makeIconHolder( icons.polar, object, iconBaseScale );
 				positionRadially(holder, iconRadius, 0, iconBasePos.y);
 
 				// store original position for later use.
@@ -974,8 +972,7 @@
 			loader.load( icons.dive.model, function ( object ) {
 
 				// create parent holder object
-				var holder = makeIconHolder( icons.dive, object );
-				holder.scale.set( iconBaseScale, iconBaseScale, iconBaseScale );
+				var holder = makeIconHolder( icons.dive, object, iconBaseScale );
 				positionRadially(holder, iconRadius, iconAngle, iconBasePos.y);
 
 				// store original position for later use.

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -1235,7 +1235,16 @@
 			effect.setSize( innerWidth, innweHeight );
 		}
 
+		window.lastRenderTime = performance.now();
+
 		function animate() {
+
+			var newLastRenderTime = performance.now();
+			var elasped = newLastRenderTime - lastRenderTime;
+			if ( elasped > 25 ){
+				console.log('long elapsed time', elasped);
+			}
+			window.lastRenderTime = newLastRenderTime;
 
 			for (var i = 0; i < particles.length; i++) {
 				var particle = particles[i];

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -100,7 +100,6 @@
 		// This state tracking is sort of ugly, and should be moved to inside VRClient and/or VRCursor.
 		VRClientFocus = false;
 		VRClientIsVR = false;
-		handsInFrame = false;
 
 
 		function init() {
@@ -116,6 +115,8 @@
 			scene = new THREE.Scene();
 
 			camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.01, 10000 );
+			scene.add(camera); // Lights are attached and must be in scene.
+
 
 			cursor = new VRCursor();
 
@@ -194,19 +195,21 @@
 
 			var handLight = new THREE.SpotLight(0xffffff, 0.25);
 			handLight.castShadow = true;
-			handLight.shadowCameraVisible = true;
+			handLight.shadowCameraVisible = false;
 			handLight.shadowCameraNear = 0.01;
 			handLight.shadowCameraFar = 3;
 			handLight.shadowDarkness = 0.8;
 
+			handLight.position.set(0,1,1);
 			handLight.target.position.set(0,0,-1);
-			scene.add(handLight.target);
+			camera.add(handLight.target);
 
 			var dolly = new THREE.Object3D;
 			dolly.position.set(0,0.2,0.8);
 
 			scene.add(dolly);
-			dolly.add(handLight);
+			camera.add(handLight);
+
 
 
 			Leap.loop();
@@ -336,6 +339,7 @@
 		/* scale things down to put them within reach */
 //		var masterScale = 0.55; // Desktop mode
 		var masterScale = 0.15; // VR Mode
+		var tileScale = 0.7;
 //		var masterScale = 1; // No Leap
 
 
@@ -725,8 +729,9 @@
 
 				var button = new PushButton(
 					new InteractablePlane(
-						imageMesh, Leap.loopController, {moveX: false, moveY: false, locking: false}
-					)
+						imageMesh, Leap.loopController, {moveX: false, moveY: false}
+					),
+					{locking: false}
 				);
 
 				var highlight = new THREE.Mesh(

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -195,8 +195,9 @@
 
 			Leap.loop()
 				.use('transform', {
-					scale: 0.001,
-					position: new THREE.Vector3(0,-0.3,-0.35),
+//					scale: 0.001,
+//					position: new THREE.Vector3(0,-0.3,-0.35),
+					vr: true,
 					effectiveParent: this.camera
 				})
 				.use('boneHand', {
@@ -299,7 +300,9 @@
 
 
 		/*====================== Make layout ======================*/
-		var masterScale = 0.055; /* scale thigns down to put them within reach */
+		/* scale things down to put them within reach */
+//		var masterScale = 0.55; // Desktop mode
+		var masterScale = 0.15; // VR Mode
 
 
 		function makeSky() {

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -96,6 +96,7 @@
 		var userHeight = -1.65;
 
 		// requirements for cursor.
+		// This state tracking is sort of ugly, and should be moved to inside VRClient and/or VRCursor.
 		VRClientFocus = false; // todo - make focus fire on load.
 		VRClientIsVR = false;
 		handsInFrame = false;

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -657,9 +657,9 @@
 
 			function makePanos() {
 
-				var w = 34 * 0.07;
-				var h = 67.25 * 0.07;
-				var d = 1 * scale;
+				var w = 34 * 0.07 * masterScale;
+				var h = 67.25 * 0.07 * masterScale;
+				var d = 1 * scale * masterScale;
 
 				// hit area
 				var group = new THREE.Mesh(
@@ -668,9 +668,16 @@
 				);
 
 				// label
-				var mesh = new THREE.Mesh(
+				var imageMesh = new THREE.Mesh(
 					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
 					new THREE.MeshBasicMaterial( { transparent: true, opacity: 1, map: THREE.ImageUtils.loadTexture( "images/txt-panos-1.png" ) } )
+				);
+				imageMesh.name = "txt-panos-1";
+
+				var button = new PushButton(
+					new InteractablePlane(
+						imageMesh, Leap.loopController, {moveX: false, moveY: false}
+					)
 				);
 
 				// highlight
@@ -678,6 +685,7 @@
 					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
 					new THREE.MeshBasicMaterial( { transparent: true, opacity: 0, color: 0x73C9EB } )
 				);
+				highlight.name = "highlight-txt-panos-1";
 
 				// events
 				group.addEventListener( 'click', function() {
@@ -696,13 +704,13 @@
 						.start();
 				});
 
-				group.add( mesh );
-				group.add( highlight );
+				imageMesh.add( highlight ); // move with the button mesh
+				group.add( imageMesh );
 
-				group.position.set(5.1, offsetY-1.2, 0.25);
+				group.position.set(2.5 * masterScale, offsetY-(1.2 * masterScale), 0.25 * masterScale);
 				group.rotation.set( 0, -105 * Math.PI / 180, 0 );
 				bend(group, 9);
-				mesh.renderDepth = 2;
+				imageMesh.renderDepth = 2;
 				highlight.renderDepth = 2;
 
 				return group;

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -859,6 +859,11 @@
 				holder.dispatchEvent({type: 'click'});
 			});
 
+			button.plane.on('travel', function(plane, mesh){
+				var scaleFactor = (mesh.position.z / button.options.longThrow);
+				holder.userData.shadow.scale.set(1 + scaleFactor, 1 + scaleFactor, 1);
+			});
+
 			iconObject.rotateX( Math.PI / 2); // inverse the dolly rotation
 			buttonMesh.add(iconObject);
 
@@ -976,7 +981,9 @@
 				// create dropshadow
 				var shadow = makeIconShadow();
 				shadow.position.setY( -130 );
+				shadow.name = "sechelt-shadow";
 				holder.add( shadow );
+				holder.userData.shadow = shadow;
 
 				scene.add(holder)
 
@@ -994,7 +1001,9 @@
 				// create dropshadow
 				var shadow = makeIconShadow();
 				shadow.position.setY( -130 );
+				shadow.name = "polar-shadow";
 				holder.add( shadow );
+				holder.userData.shadow = shadow;
 
 				scene.add(holder)
 
@@ -1012,7 +1021,9 @@
 				// create dropshadow
 				var shadow = makeIconShadow();
 				shadow.position.setY( -130 );
+				shadow.name = "dive-shadow";
 				holder.add( shadow );
+				holder.userData.shadow = shadow;
 
 				holder.add( makeInfoDive() );
 

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -25,12 +25,17 @@
 	<body>
 
 	</body>
-	<script src="../../js/vendor/three.min.js"></script>
+	<!--<script src="../../js/vendor/three.min.js"></script>-->
+	<script src="//cdnjs.cloudflare.com/ajax/libs/three.js/r69/three.js"></script>
 	<script src="../../js/vendor/tween.min.js"></script>
 	<script src="../../js/vendor/VRControls.js"></script>
 	<script src="../../js/vendor/VREffect.js"></script>
 	<script src="../../js/vendor/DeviceOrientationControls.js"></script>
 	<script src="../../js/vendor/StereoEffect.js"></script>
+
+	<script src="//js.leapmotion.com/leap-0.6.4.js"></script>
+	<script src="../../js/vendor/leap-plugins-0.1.11pre.js"></script>
+	<script src="../../js/vendor/leap-widgets-0.1.0.js"></script>
 
 	<!-- This is a library that allows this application to communicate with the main JAVRIS application host -->
 	<script src="../../js/vrclient.js"></script>
@@ -101,7 +106,7 @@
 
 			scene = new THREE.Scene();
 
-			camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 10000 );
+			camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.01, 10000 );
 
 			cursor = new VRCursor();
 
@@ -166,6 +171,25 @@
 				VRClient.ready();
 			}, 1000);
 
+
+
+
+			// makes the icons far too bright.
+//			var handLight = new THREE.PointLight(0xffffff, 1, 1);
+//			handLight.position.setY(0.3);
+//			this.scene.add(handLight);
+
+			Leap.loop()
+				.use('transform', {
+					scale: 0.001,
+					position: new THREE.Vector3(0,-0.3,-0.35),
+					effectiveParent: this.camera
+				})
+				.use('boneHand', {
+					scene: this.scene,
+					arm: true
+				})
+				.use('proximity');
 		}
 
 		// bend function
@@ -241,6 +265,7 @@
 
 
 		/*====================== Make layout ======================*/
+		var masterScale = 0.055; /* scale thigns down to put them within reach */
 
 
 		function makeSky() {
@@ -429,10 +454,10 @@
 
 			// text links
 
-			var scale = 0.1; // pixel scale
+			var scale = 0.1 * masterScale; // pixel scale
 			var segmentsX = 20;
 			var segmentsY = 1;
-			var depth = 4;
+			var depth = 4 * masterScale;
 			var offsetY = 1;
 
 			function makeSechelt() {
@@ -496,16 +521,16 @@
 				// hit area
 				var group = new THREE.Mesh(
 					new THREE.BoxGeometry( w, h, d, 1, 1 ),
-					new THREE.MeshBasicMaterial({ color: 0xffffff, transparent:true, opacity: 0, depthTest: false})
+					new THREE.MeshBasicMaterial({ color: 0xffffff, transparent:false, opacity: 0, depthTest: false})
 				);
 
 				var mesh = new THREE.Mesh(
 					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
-					new THREE.MeshBasicMaterial( { transparent: true, opacity: 1, map: THREE.ImageUtils.loadTexture( "images/txt-polarsea-3.png" ) } )
+					new THREE.MeshBasicMaterial( { transparent: false, opacity: 1, map: THREE.ImageUtils.loadTexture( "images/txt-polarsea-3.png" ) } )
 				);
 				var highlight = new THREE.Mesh(
 					new THREE.PlaneGeometry( w, h, segmentsX, segmentsY ),
-					new THREE.MeshBasicMaterial( { transparent: true, opacity: 0, color: 0x73C9EB } )
+					new THREE.MeshBasicMaterial( { transparent: false, opacity: 0, color: 0x73C9EB } )
 				);
 
 				// events
@@ -528,7 +553,7 @@
 				group.add( mesh );
 				group.add( highlight );
 
-				group.position.set(0, offsetY, -depth - 3);
+//				group.position.set(1, offsetY, -depth - (3 * masterScale) );
 				bend(group, depth);
 				mesh.renderDepth = 2;
 				highlight.renderDepth = 2;
@@ -840,7 +865,7 @@
 		/*====================== Make icons ======================*/
 
 
-		function makeIconHolder( json ) {
+		function makeIconHolder( json, iconObject ) {
 
 
 			// holder
@@ -848,7 +873,35 @@
 			var holder = new THREE.Mesh(
 				new THREE.BoxGeometry( 160, 100, 180, 1, 1 ),
 				new THREE.MeshBasicMaterial ({ color: 0xffffff, transparent:true, opacity: 0, depthTest: false} )
-			)
+			);
+
+			var buttonMesh = new THREE.Mesh(
+				new THREE.CircleGeometry(100, 8),
+				new THREE.MeshBasicMaterial ({ transparent:true, opacity: 0, depthTest: false, depthWrite: false} ) // hide default button visuals
+			);
+			buttonMesh.name = "collider";
+
+			// The button always moves along the z axis. Create wrapper for it.
+			var dolly = new THREE.Object3D();
+			dolly.rotateX( - Math.PI / 2);
+			dolly.name = "collider-dolly";
+
+			dolly.add(buttonMesh);
+			holder.add(dolly);
+
+			var button = new PushButton(
+				new InteractablePlane(buttonMesh, Leap.loopController, {moveX: false, moveY: false}),
+				{locking: false}
+			);
+
+			button.longThrow = -35;
+			button.shortThrow = -20;
+			button.on('press', function(){
+				holder.dispatchEvent({type: 'click'});
+			});
+
+			iconObject.rotateX( Math.PI / 2); // inverse the dolly rotation
+			buttonMesh.add(iconObject);
 
 
 			// popup
@@ -881,14 +934,14 @@
 
 				// set tween destination position by starting with canonical position, as stored in the object's userData
 
-				var destinationY = e.target.userData.position.y + 0.1;
+				var destinationY = e.target.userData.position.y + (0.1 * masterScale);
 
 				new TWEEN.Tween( e.target.position )
 					.to( { y: destinationY }, 350 )
 					.start();
 
 				new TWEEN.Tween( popup.position )
-					.to( { y: posY + 3 }, 200 )
+					.to( { y: posY + (3 * masterScale) }, 200 )
 					.start();
 
 				new TWEEN.Tween( mesh.material )
@@ -939,27 +992,23 @@
 			var loader = new THREE.ObjectLoader();
 			var iconBasePos = {// base positioning of icons position.
 				x: 0,
-				y: 0.6 + userHeight,
-				z: -4.5
+				y: (0.6 + userHeight) * masterScale,
+				z: -4.5 * masterScale
 			};
-			var iconBaseScale = 0.015;	// scale icons
-			var spread = 4.5;	// spread between icons
-			var depth = 10;	// depth at which icons are placed.
-
+			var iconBaseScale = 0.015 * masterScale;	// scale icons
 
 			loader.load( icons.sechelt.model, function ( object ) {
 
 				// relative object positioning to iconBasePos.
-				var x = iconBasePos.x - 2.25,
-					y = iconBasePos.y + 0.2,
-					z = iconBasePos.z + 2.5;
+				var x = iconBasePos.x - (2.25 * masterScale),
+					  y = iconBasePos.y + (0.2 * masterScale),
+					  z = iconBasePos.z + (2.5 * masterScale);
 
 				// create parent holder object
-				var holder = makeIconHolder( icons.sechelt );
+				var holder = makeIconHolder( icons.sechelt, object );
 				holder.scale.set( iconBaseScale, iconBaseScale, iconBaseScale );
 				holder.position.set( x, y, z);
 				holder.rotation.set( 0, 130 * (Math.PI/180), 0 );
-				holder.add( object );
 
 				// store original position for later use.
 				holder.userData.position = new THREE.Vector3(x, y, z);
@@ -976,16 +1025,15 @@
 			loader.load( icons.polar.model, function ( object ) {
 
 				// relative object positioning to iconBasePos.
-				var x = iconBasePos.x + 0,
-					y = iconBasePos.y + 0
-					z = iconBasePos.z - 0.5;
+				var x = iconBasePos.x + (0   * masterScale),
+				   	y = iconBasePos.y + (0   * masterScale),
+					  z = iconBasePos.z - (0.5 * masterScale);
 
 				// create parent holder object
-				var holder = makeIconHolder( icons.polar );
+				var holder = makeIconHolder( icons.polar, object );
 				holder.scale.set( iconBaseScale, iconBaseScale, iconBaseScale );
 				holder.position.set( x, y, z);
 				holder.rotation.set( 0, 80 * (Math.PI/180), 0 );
-				holder.add( object );
 
 				// store original position for later use.
 				holder.userData.position = new THREE.Vector3(x, y, z);
@@ -1002,16 +1050,15 @@
 			loader.load( icons.dive.model, function ( object ) {
 
 				// relative object positioning to iconBasePos.
-				var x = iconBasePos.x + 2.25,
-					y = iconBasePos.y + 0.2,
-					z = iconBasePos.z + 2.5;
+				var x = iconBasePos.x + (2.25 * masterScale),
+					  y = iconBasePos.y + (0.2 * masterScale),
+					  z = iconBasePos.z + (2.5 * masterScale);
 
 				// create parent holder object
-				var holder = makeIconHolder( icons.dive );
+				var holder = makeIconHolder( icons.dive, object );
 				holder.scale.set( iconBaseScale, iconBaseScale, iconBaseScale );
 				holder.position.set( x, y, z);
 				holder.rotation.set( 0, 35 * (Math.PI/180), 0 );
-				holder.add( object );
 				//holder.add( makeInfoDive() );
 
 				// store original position for later use.

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -177,9 +177,9 @@
 				updateCursorState();
 			}
 
-			var light = new THREE.DirectionalLight( 0xffffff, 0.15 );
-			light.position.set( 100, 110, 150 );
-			scene.add( light );
+//			var light = new THREE.DirectionalLight( 0xffffff, 0.15 );
+//			light.position.set( 100, 110, 150 );
+//			scene.add( light );
 
 			// Announce to Javris that everything is ready to go and we can reveal content.
 			setTimeout(function() {
@@ -189,10 +189,9 @@
 
 
 
-			// makes the icons far too bright.
-//			var handLight = new THREE.PointLight(0xffffff, 1, 1);
-//			handLight.position.setY(0.3);
-//			this.scene.add(handLight);
+			var handLight = new THREE.PointLight(0xffffff, 1, 1);
+			handLight.position.setY(0.3);
+			this.scene.add(handLight);
 
 			Leap.loop()
 				.use('transform', {

--- a/content/construct/index.html
+++ b/content/construct/index.html
@@ -823,7 +823,16 @@
 		/*====================== Make icons ======================*/
 
 
-		function makeIconHolder( json, iconObject, scale ) {
+		function makeIconHolder( json, iconObject, iconAngle ) {
+
+
+			var iconRadius = 0.56; // same as tileRadius
+			var iconBasePos = {// base positioning of icons position.
+				x: 0,
+				y: (0.6 + userHeight) * masterScale,
+				z: -4.5 * masterScale
+			};
+			var iconBaseScale = 0.015 * masterScale;	// scale icons
 
 
 			// holder
@@ -939,7 +948,21 @@
 					.start();
 			})
 
-			holder.scale.multiplyScalar(scale);
+			holder.scale.multiplyScalar(iconBaseScale);
+
+
+
+			positionRadially(holder, iconRadius, iconAngle, iconBasePos.y);
+
+			// store original position for later use.
+			holder.userData.position = holder.position.clone();
+
+			// create dropshadow
+			var shadow = makeIconShadow();
+			shadow.position.setY( -130 );
+			holder.add( shadow );
+			holder.userData.shadow = shadow;
+
 
 			return holder;
 
@@ -959,31 +982,14 @@
 
 		function populateIcons() {
 
-			var iconRadius = 0.56; // same as tileRadius
 
 			var loader = new THREE.ObjectLoader();
-			var iconBasePos = {// base positioning of icons position.
-				x: 0,
-				y: (0.6 + userHeight) * masterScale,
-				z: -4.5 * masterScale
-			};
-			var iconBaseScale = 0.015 * masterScale;	// scale icons
+
 
 			loader.load( icons.sechelt.model, function ( object ) {
 
 				// create parent holder object
-				var holder = makeIconHolder( icons.sechelt, object, iconBaseScale );
-				positionRadially(holder, iconRadius, -iconAngle, iconBasePos.y);
-
-				// store original position for later use.
-				holder.userData.position = holder.position.clone();
-
-				// create dropshadow
-				var shadow = makeIconShadow();
-				shadow.position.setY( -130 );
-				shadow.name = "sechelt-shadow";
-				holder.add( shadow );
-				holder.userData.shadow = shadow;
+				var holder = makeIconHolder( icons.sechelt, object, -iconAngle );
 
 				scene.add(holder)
 
@@ -992,18 +998,7 @@
 			loader.load( icons.polar.model, function ( object ) {
 
 				// create parent holder object
-				var holder = makeIconHolder( icons.polar, object, iconBaseScale );
-				positionRadially(holder, iconRadius, 0, iconBasePos.y);
-
-				// store original position for later use.
-				holder.userData.position = holder.position.clone();
-
-				// create dropshadow
-				var shadow = makeIconShadow();
-				shadow.position.setY( -130 );
-				shadow.name = "polar-shadow";
-				holder.add( shadow );
-				holder.userData.shadow = shadow;
+				var holder = makeIconHolder( icons.polar, object, 0 );
 
 				scene.add(holder)
 
@@ -1012,20 +1007,7 @@
 			loader.load( icons.dive.model, function ( object ) {
 
 				// create parent holder object
-				var holder = makeIconHolder( icons.dive, object, iconBaseScale );
-				positionRadially(holder, iconRadius, iconAngle, iconBasePos.y);
-
-				// store original position for later use.
-				holder.userData.position = holder.position.clone();
-
-				// create dropshadow
-				var shadow = makeIconShadow();
-				shadow.position.setY( -130 );
-				shadow.name = "dive-shadow";
-				holder.add( shadow );
-				holder.userData.shadow = shadow;
-
-				holder.add( makeInfoDive() );
+				var holder = makeIconHolder( icons.dive, object, iconAngle );
 
 				scene.add(holder)
 

--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
 
   </body>
   <script src="//cdnjs.cloudflare.com/ajax/libs/three.js/r69/three.js"></script>
+  <!--<script src="js/vendor/OrbitControls.js"></script>-->
   <script src="js/vendor/VRControls.js"></script>
   <script src="js/vendor/DeviceOrientationControls.js"></script>
   <script src="js/vendor/VREffect.js"></script>

--- a/js/lib/dom2three.js
+++ b/js/lib/dom2three.js
@@ -204,6 +204,10 @@ var DOM2three = (function() {
 
 			var rectangle = node.rectangle;
 
+			// Note that this generates some amount of waste, as the same texture is moved to the GPU several times
+			// with different mappings. It's unclear if there's a way to optimize here.
+			//var texture = self.texture;
+
 			var texture = self.texture.clone();
 			texture.repeat.x = rectangle.width / texture.image.width;
 			texture.repeat.y = rectangle.height / texture.image.height;

--- a/js/vendor/leap-plugins-0.1.11pre.js
+++ b/js/vendor/leap-plugins-0.1.11pre.js
@@ -1,5 +1,5 @@
 /*    
- * LeapJS-Plugins  - v0.1.11pre - 2014-11-25    
+ * LeapJS-Plugins  - v0.1.11pre - 2014-12-03    
  * http://github.com/leapmotion/leapjs-plugins/    
  *    
  * Copyright 2014 LeapMotion, Inc    
@@ -27,9 +27,11 @@
   initScene = function(targetEl, scale) {
     var camera, directionalLight, far, height, near, renderer, width;
     scope.scene = new THREE.Scene();
-    scope.renderer = renderer = new THREE.WebGLRenderer({
-      alpha: true
-    });
+    scope.rendererOps || (scope.rendererOps = {});
+    if (scope.rendererOps.alpha === void 0) {
+      scope.rendererOps.alpha = true;
+    }
+    scope.renderer = renderer = new THREE.WebGLRenderer(scope.rendererOps);
     width = window.innerWidth;
     height = window.innerHeight;
     renderer.setClearColor(0x000000, 0);
@@ -52,7 +54,7 @@
       far *= scale;
     }
     scope.camera = camera = new THREE.PerspectiveCamera(45, width / height, near, far);
-    camera.position.fromArray([0, 300, 500]);
+    camera.position.set(0, 300, 500);
     camera.lookAt(new THREE.Vector3(0, 160, 0));
     scope.scene.add(camera);
     window.addEventListener('resize', function() {
@@ -110,6 +112,9 @@
       mesh = new HandMesh;
       mesh.setVisibility(false);
       HandMesh.unusedHandMeshes.push(mesh);
+      if (HandMesh.onMeshCreated) {
+        HandMesh.onMeshCreated(mesh);
+      }
       return mesh;
     };
 
@@ -133,17 +138,20 @@
           mesh.name = "hand-bone-" + j;
           mesh.material.color.copy(jointColor);
           mesh.renderDepth = ((i * 9) + (2 * j)) / 36;
+          mesh.castShadow = true;
           scope.scene.add(mesh);
           finger.push(mesh);
           mesh = new THREE.Mesh(new THREE.CylinderGeometry(boneRadius, boneRadius, 40, 32), material.clone());
           mesh.name = "hand-joint-" + j;
           mesh.material.color.copy(boneColor);
           mesh.renderDepth = ((i * 9) + (2 * j) + 1) / 36;
+          mesh.castShadow = true;
           scope.scene.add(mesh);
           finger.push(mesh);
         }
         mesh = new THREE.Mesh(new THREE.SphereGeometry(jointRadius, 32, 32), material.clone());
         mesh.material.color.copy(jointColor);
+        mesh.castShadow = true;
         scope.scene.add(mesh);
         finger.push(mesh);
         this.fingerMeshes.push(finger);
@@ -155,6 +163,8 @@
         for (i = _k = 0; _k <= 3; i = ++_k) {
           this.armBones.push(new THREE.Mesh(new THREE.CylinderGeometry(boneRadius, boneRadius, (i < 2 ? 1000 : 100), 32), material.clone()));
           this.armBones[i].material.color.copy(boneColor);
+          this.armBones[i].castShadow = true;
+          this.armBones[i].name = "ArmBone" + i;
           if (i > 1) {
             this.armBones[i].quaternion.multiply(armTopAndBottomRotation);
           }
@@ -164,11 +174,25 @@
         for (i = _l = 0; _l <= 3; i = ++_l) {
           this.armSpheres.push(new THREE.Mesh(new THREE.SphereGeometry(jointRadius, 32, 32), material.clone()));
           this.armSpheres[i].material.color.copy(jointColor);
+          this.armSpheres[i].castShadow = true;
+          this.armSpheres[i].name = "ArmSphere" + i;
           this.armMesh.add(this.armSpheres[i]);
         }
         scope.scene.add(this.armMesh);
       }
     }
+
+    HandMesh.prototype.traverse = function(callback) {
+      var i, mesh, _i, _j, _len, _ref;
+      for (i = _i = 0; _i < 5; i = ++_i) {
+        _ref = this.fingerMeshes[i];
+        for (_j = 0, _len = _ref.length; _j < _len; _j++) {
+          mesh = _ref[_j];
+          callback(mesh);
+        }
+      }
+      return this.armMesh.traverse(callback);
+    };
 
     HandMesh.prototype.scaleTo = function(hand) {
       var armLenScale, armWidthScale, baseScale, bone, boneXOffset, finger, fingerBoneLengthScale, halfArmLength, i, j, mesh, _i, _j;
@@ -286,6 +310,9 @@
     if (!handMesh) {
       handMesh = HandMesh.get().scaleTo(hand);
       hand.data('handMesh', handMesh);
+      if (HandMesh.onMeshUsed) {
+        HandMesh.onMeshUsed(handMesh);
+      }
     }
     return handMesh.formTo(hand);
   };
@@ -300,7 +327,7 @@
   };
 
   Leap.plugin('boneHand', function(options) {
-    var scale;
+    var controller, scale;
     if (options == null) {
       options = {};
     }
@@ -319,6 +346,13 @@
     jointRadius = null;
     material = null;
     armTopAndBottomRotation = (new THREE.Quaternion).setFromEuler(new THREE.Euler(0, 0, Math.PI / 2));
+    controller = this;
+    HandMesh.onMeshCreated = function(mesh) {
+      return controller.emit('handMeshCreated', mesh);
+    };
+    HandMesh.onMeshUsed = function(mesh) {
+      return controller.emit('handMeshUsed', mesh);
+    };
     this.use('handEntry');
     this.use('handHold');
     if (scope.scene === void 0) {

--- a/js/vendor/leap-plugins-0.1.11pre.js
+++ b/js/vendor/leap-plugins-0.1.11pre.js
@@ -1,5 +1,5 @@
 /*    
- * LeapJS-Plugins  - v0.1.11pre - 2014-12-16    
+ * LeapJS-Plugins  - v0.1.11pre - 2014-12-18    
  * http://github.com/leapmotion/leapjs-plugins/    
  *    
  * Copyright 2014 LeapMotion, Inc    
@@ -332,14 +332,14 @@
       options = {};
     }
     scope = options;
+    jointColor = (new THREE.Color).setHex(0x5daa00);
+    boneColor = (new THREE.Color).setHex(0xffffff);
     scope.boneScale && (boneScale = scope.boneScale);
     scope.jointScale && (jointScale = scope.jointScale);
     scope.boneColor && (boneColor = scope.boneColor);
     scope.jointColor && (jointColor = scope.jointColor);
     scope.HandMesh = HandMesh;
     baseBoneRotation = (new THREE.Quaternion).setFromEuler(new THREE.Euler(Math.PI / 2, 0, 0));
-    jointColor = (new THREE.Color).setHex(0x5daa00);
-    boneColor = (new THREE.Color).setHex(0xffffff);
     boneScale = 1 / 6;
     jointScale = 1 / 5;
     boneRadius = null;

--- a/js/vendor/leap-plugins-0.1.11pre.js
+++ b/js/vendor/leap-plugins-0.1.11pre.js
@@ -1,5 +1,5 @@
 /*    
- * LeapJS-Plugins  - v0.1.11pre - 2014-12-03    
+ * LeapJS-Plugins  - v0.1.11pre - 2014-12-16    
  * http://github.com/leapmotion/leapjs-plugins/    
  *    
  * Copyright 2014 LeapMotion, Inc    
@@ -191,7 +191,7 @@
           callback(mesh);
         }
       }
-      return this.armMesh.traverse(callback);
+      return this.armMesh && this.armMesh.traverse(callback);
     };
 
     HandMesh.prototype.scaleTo = function(hand) {
@@ -2461,8 +2461,6 @@ More info on vec3 can be found, here: http://glmatrix.net/docs/2.2.0/symbols/vec
 
 //CoffeeScript generated from main/transform/leap.transform.coffee
 (function() {
-  var __slice = [].slice;
-
   Leap.plugin('transform', function(scope) {
     var noop, transformDirections, transformMat4Implicit0, transformPositions, transformWithMatrices, _directionTransform;
     if (scope == null) {
@@ -2511,9 +2509,8 @@ More info on vec3 can be found, here: http://glmatrix.net/docs/2.2.0/symbols/vec
         return scope.scale;
       }
     };
-    transformPositions = function() {
-      var matrix, vec3, vec3s, _i, _len, _results;
-      matrix = arguments[0], vec3s = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
+    transformPositions = function(matrix, vec3s) {
+      var vec3, _i, _len, _results;
       _results = [];
       for (_i = 0, _len = vec3s.length; _i < _len; _i++) {
         vec3 = vec3s[_i];
@@ -2535,9 +2532,8 @@ More info on vec3 can be found, here: http://glmatrix.net/docs/2.2.0/symbols/vec
       out[2] = m[2] * x + m[6] * y + m[10] * z;
       return out;
     };
-    transformDirections = function() {
-      var matrix, vec3, vec3s, _i, _len, _results;
-      matrix = arguments[0], vec3s = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
+    transformDirections = function(matrix, vec3s) {
+      var vec3, _i, _len, _results;
       _results = [];
       for (_i = 0, _len = vec3s.length; _i < _len; _i++) {
         vec3 = vec3s[_i];
@@ -2551,18 +2547,18 @@ More info on vec3 can be found, here: http://glmatrix.net/docs/2.2.0/symbols/vec
     };
     transformWithMatrices = function(hand, transform, scale) {
       var finger, scalarScale, _i, _j, _len, _len1, _ref, _ref1;
-      transformDirections(transform, hand.direction, hand.palmNormal, hand.palmVelocity, hand.arm.basis[0], hand.arm.basis[1], hand.arm.basis[2]);
+      transformDirections(transform, [hand.direction, hand.palmNormal, hand.palmVelocity, hand.arm.basis[0], hand.arm.basis[1], hand.arm.basis[2]]);
       _ref = hand.fingers;
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         finger = _ref[_i];
-        transformDirections(transform, finger.direction, finger.metacarpal.basis[0], finger.metacarpal.basis[1], finger.metacarpal.basis[2], finger.proximal.basis[0], finger.proximal.basis[1], finger.proximal.basis[2], finger.medial.basis[0], finger.medial.basis[1], finger.medial.basis[2], finger.distal.basis[0], finger.distal.basis[1], finger.distal.basis[2]);
+        transformDirections(transform, [finger.direction, finger.metacarpal.basis[0], finger.metacarpal.basis[1], finger.metacarpal.basis[2], finger.proximal.basis[0], finger.proximal.basis[1], finger.proximal.basis[2], finger.medial.basis[0], finger.medial.basis[1], finger.medial.basis[2], finger.distal.basis[0], finger.distal.basis[1], finger.distal.basis[2]]);
       }
       Leap.glMatrix.mat4.scale(transform, transform, scale);
-      transformPositions(transform, hand.palmPosition, hand.stabilizedPalmPosition, hand.sphereCenter, hand.arm.nextJoint, hand.arm.prevJoint);
+      transformPositions(transform, [hand.palmPosition, hand.stabilizedPalmPosition, hand.sphereCenter, hand.arm.nextJoint, hand.arm.prevJoint]);
       _ref1 = hand.fingers;
       for (_j = 0, _len1 = _ref1.length; _j < _len1; _j++) {
         finger = _ref1[_j];
-        transformPositions(transform, finger.carpPosition, finger.mcpPosition, finger.pipPosition, finger.dipPosition, finger.distal.nextJoint, finger.tipPosition);
+        transformPositions(transform, [finger.carpPosition, finger.mcpPosition, finger.pipPosition, finger.dipPosition, finger.distal.nextJoint, finger.tipPosition]);
       }
       scalarScale = (scale[0] + scale[1] + scale[2]) / 3;
       return hand.arm.width *= scalarScale;

--- a/js/vendor/leap-widgets-0.1.0.js
+++ b/js/vendor/leap-widgets-0.1.0.js
@@ -23,6 +23,11 @@ window.InteractablePlane = function(planeMesh, controller, options){
   this.options.highlight  !== undefined|| (this.options.highlight = true); // this can be configured through this.highlightMesh
 
   this.mesh = planeMesh;
+
+  if (!(controller instanceof Leap.Controller)) {
+    throw "No Controller Given"
+  }
+
   this.controller = controller;
   this.lastPosition = null;
 
@@ -640,7 +645,6 @@ Leap._.extend(InteractablePlane.prototype, Leap.EventEmitter.prototype);
 // are there any potential cases where such a thing would be bad?
 // - if the base shape had to be rotated to appear correct
 // it would be nice to not have to wrap a button, just to rotate it.
-// todo - add locking option
 // todo - dispatch click event
 var PushButton = function(interactablePlane, options){
   'use strict';
@@ -654,7 +658,7 @@ var PushButton = function(interactablePlane, options){
   this.options = options || (options = {});
 
   // A distinct "Pressed in/active" state.
-  this.options.locking  !== undefined || (this.options.locking   = true);
+  this.options.locking  !== undefined || (this.options.locking = true);
 
   // Todo - these should be a percentage of the button size, perhaps.
   this.longThrow  = -0.05;
@@ -676,7 +680,6 @@ PushButton.prototype.bindLocking = function(){
     this.pressed = true;
 
     this.plane.movementConstraints.z = this.pressedConstraint.bind(this);
-    this.plane.mesh.material.color.setHex(0xccccff);
 
   }.bind(this));
 
@@ -684,7 +687,6 @@ PushButton.prototype.bindLocking = function(){
     this.pressed = false;
 
     this.plane.movementConstraints.z = this.releasedConstraint.bind(this);
-    this.plane.mesh.material.color.setHex(0xeeeeee);
 
   }.bind(this));
 
@@ -704,7 +706,7 @@ PushButton.prototype.releasedConstraint = function(z){
   if (z < origZ + this.longThrow){
     if (!this.pressed && this.canChangeState){
       this.canChangeState = false;
-      this.emit('press');
+      this.emit('press', this.plane.mesh);
     }
     return origZ + this.longThrow;
   }
@@ -724,7 +726,7 @@ PushButton.prototype.pressedConstraint = function(z){
   if (z < origZ + this.longThrow){
     if (this.pressed && this.canRelease) {
       this.canRelease = false;
-      this.emit('release');
+      this.emit('release', this.plane.mesh);
     }
     return origZ + this.longThrow;
   }

--- a/js/vendor/leap-widgets-0.1.0.js
+++ b/js/vendor/leap-widgets-0.1.0.js
@@ -18,7 +18,7 @@ window.InteractablePlane = function(planeMesh, controller, options){
   this.options.moveZ  !== undefined    || (this.options.moveZ   = false );
   this.options.highlight  !== undefined|| (this.options.highlight = true); // this can be configured through this.highlightMesh
   this.options.damping !== undefined   || (this.options.damping = 0.12); // this can be configured through this.highlightMesh
-  this.options.hoverBounds !== undefined   || (this.options.hoverBounds = [0, 0.32]);  // react to hover within 3cm.
+  this.options.hoverBounds !== undefined  || (this.options.hoverBounds = [0, 0.32]);  // react to hover within 3cm.
 
   this.mesh = planeMesh;
 
@@ -233,11 +233,12 @@ window.InteractablePlane.prototype = {
 
   },
 
-  cleanupHandData: function(hand){
+  cleanupHandData: function (hand) {
     var key;
 
-    for (var i = 0; i < 5; i++){
-      key = hand.id + '-' + i;
+    var points = this.interactiveJoints(hand);
+    for (var i = 0; i < points.length; i++) {
+      key = hand.id + "-" + i;
       delete this.intersections[key];
       delete this.previousOverlap[key];
     }

--- a/js/vendor/leap-widgets-0.1.0.js
+++ b/js/vendor/leap-widgets-0.1.0.js
@@ -11,7 +11,7 @@
 // there's very nothing in this class which cares if it is a box or a plane.
 
 (function() {
-
+  'use strict';
 
 window.InteractablePlane = function(planeMesh, controller, options){
   this.options = options || {};
@@ -640,20 +640,37 @@ Leap._.extend(InteractablePlane.prototype, Leap.EventEmitter.prototype);
 // are there any potential cases where such a thing would be bad?
 // - if the base shape had to be rotated to appear correct
 // it would be nice to not have to wrap a button, just to rotate it.
+// todo - add locking option
+// todo - dispatch click event
+var PushButton = function(interactablePlane, options){
+  'use strict';
 
-var PushButton = function(interactablePlane){
   this.plane = interactablePlane;
   this.plane.returnSpringK = this.plane.mass / 25;
   this.plane.options.moveX = false;
   this.plane.options.moveY = false;
   this.plane.options.moveZ = true;
 
+  this.options = options || (options = {});
+
+  // A distinct "Pressed in/active" state.
+  this.options.locking  !== undefined || (this.options.locking   = true);
+
+  // Todo - these should be a percentage of the button size, perhaps.
   this.longThrow  = -0.05;
   this.shortThrow = -0.03;
 
   this.pressed = false;
   this.canChangeState = true;
   this.plane.movementConstraints.z = this.releasedConstraint.bind(this);
+
+  if (this.options.locking){
+    this.bindLocking();
+  }
+
+};
+
+PushButton.prototype.bindLocking = function(){
 
   this.on('press', function(){
     this.pressed = true;
@@ -1159,6 +1176,7 @@ Leap.plugin('proximity', function(scope){
 
 
 (function() {
+  'use strict';
 
 // Returns the positions of all the corners of the box
 // Uses CSS ordering conventions: CW from TL.  First front face corners, then back.

--- a/js/vrclient.js
+++ b/js/vrclient.js
@@ -61,11 +61,13 @@ window.VRClient = (function() {
           self.zeroSensor();
           break;
         case 'onBlur':
+          window.dispatchEvent(new Event('blur'));
           if (typeof self.onBlur == 'function') {
             self.onBlur();
           }
           break;
         case 'onFocus':
+          window.dispatchEvent(new Event('focus'));
           if (typeof self.onFocus == 'function') {
             self.onFocus();
           }

--- a/js/vrcursor.js
+++ b/js/vrcursor.js
@@ -505,7 +505,7 @@ VRCursor.prototype.updateCursorIntersection = function() {
   }
 
 
-  var intersects = raycaster.intersectObjects( this.context.children );
+  var intersects = raycaster.intersectObjects( this.context.children, true );
 
   var intersected;
   var i;

--- a/js/vrhud.js
+++ b/js/vrhud.js
@@ -208,6 +208,15 @@ VRHud.prototype.attachEvents = function(favorites) {
 			}
 		});
 
+
+		if (Leap.loopController){
+			mesh.userData.button = new PushButton(
+				new InteractablePlane( mesh, Leap.loopController, {moveX: false, moveY: false} ),
+				{ locking: false }
+			);
+		}
+
+
 	});
 }
 
@@ -240,14 +249,6 @@ VRHud.prototype.makeLayout = function(nodes) {
 
 			holder.userData.position = holder.position.clone();
 			holder.userData.scale    = holder.scale.clone();
-
-			if (Leap.loopController){
-				mesh.userData.button = new PushButton(
-					new InteractablePlane( mesh, Leap.loopController, {moveX: false, moveY: false} ),
-					{ locking: false }
-				);
-			}
-
 
 			// here turn these in to interactable planes/buttons
 			// make them initially uninteractable

--- a/js/vrhud.js
+++ b/js/vrhud.js
@@ -11,6 +11,7 @@ function VRHud() {
 	this.homeButtonMesh = null;
 	this.d23 = null;
 	this.enabled = false;
+	this.leapActivated = false;
 
 	function loadJson(url) {
 		return new Promise( function(resolve, reject) {
@@ -145,6 +146,8 @@ VRHud.prototype.hide = function() {
 					})
 					.start();
 			}
+
+			self.leapActivated = false;
 
 
 		} else {

--- a/js/vrhud.js
+++ b/js/vrhud.js
@@ -163,8 +163,6 @@ VRHud.prototype.hide = function(instantaneous) {
 
 				mesh.material.opacity = 1;
 
-				// should set interactable to false here
-
 				new TWEEN.Tween( mesh.material )
 					.to({ opacity: 0 }, 500 )
 					.easing(TWEEN.Easing.Exponential.Out)
@@ -308,7 +306,6 @@ VRHud.prototype.setInteractable = function(state){
 		button = meshes[i].children[0].userData.button;
 		if (!button) continue;
 
-		console.log('s', state);
 		button.plane.safeSetInteractable(state)
 
 	}
@@ -334,6 +331,7 @@ VRHud.prototype.makeLayout = function(nodes) {
 			mesh.position.multiplyScalar(hudScale);
 			holder.positionRadially( hudRadius, mesh.position.x / hudRadius, mesh.position.y );
 			mesh.position.set(0,0,0);  // Remove initial positioning from d23
+			mesh.scale.z = 1; // Remove initial z scaling, which ensures that buttons get pushed correctly w/o flicker.
 
 			mesh.geometry.bend( hudRadius, mesh );
 
@@ -342,9 +340,6 @@ VRHud.prototype.makeLayout = function(nodes) {
 
 			holder.userData.position = holder.position.clone();
 			holder.userData.scale    = holder.scale.clone();
-
-			// here turn these in to interactable planes/buttons
-			// make them initially uninteractable
 		});
 
 

--- a/js/vrhud.js
+++ b/js/vrhud.js
@@ -242,9 +242,10 @@ VRHud.prototype.attachEvents = function(favorites) {
 
 
 		if (Leap.loopController){
+
 			var button = mesh.userData.button = new PushButton(
 				new InteractablePlane( mesh, Leap.loopController, {moveX: false, moveY: false} ),
-				{ locking: false }
+				{ locking: false, longThrow: -0.1 }
 			);
 
 			mesh.receiveShadow = true;
@@ -254,7 +255,8 @@ VRHud.prototype.attachEvents = function(favorites) {
 
 				if ( !self.visible ) return;
 
-				mesh.dispatchEvent({type: 'click'});
+				//mesh.dispatchEvent({type: 'click'});
+				console.log('would be navigating :)');
 
 			} );
 

--- a/js/vrhud.js
+++ b/js/vrhud.js
@@ -210,10 +210,16 @@ VRHud.prototype.attachEvents = function(favorites) {
 
 
 		if (Leap.loopController){
-			mesh.userData.button = new PushButton(
+			var button = mesh.userData.button = new PushButton(
 				new InteractablePlane( mesh, Leap.loopController, {moveX: false, moveY: false} ),
 				{ locking: false }
 			);
+
+			mesh.receiveShadow = true;
+
+			button.on('press', function(){
+				mesh.dispatchEvent({type: 'click'});
+			});
 		}
 
 

--- a/js/vrhud.js
+++ b/js/vrhud.js
@@ -255,8 +255,7 @@ VRHud.prototype.attachEvents = function(favorites) {
 
 				if ( !self.visible ) return;
 
-				//mesh.dispatchEvent({type: 'click'});
-				console.log('would be navigating :)');
+				mesh.dispatchEvent({type: 'click'});
 
 			} );
 

--- a/js/vrhud.js
+++ b/js/vrhud.js
@@ -82,7 +82,8 @@ VRHud.prototype.show = function() {
 				mesh.position.set(mesh.userData.position.x, mesh.userData.position.y - 1, mesh.userData.position.z + 1);
 
 				var tween = new TWEEN.Tween( mesh.position )
-					.to({ x: mesh.userData.position.x, y: mesh.userData.position.y, z: mesh.userData.position.z}, 700 )
+					//.to( mesh.userData.position, 700 ) // For some reason, this seems to append NaN to the .position constructor method source. https://github.com/sole/tween.js/issues/175
+					.to( { x: mesh.userData.position.x, y: mesh.userData.position.y, z: mesh.userData.position.z}, 700 )
 					.easing(TWEEN.Easing.Exponential.Out)
 					.delay( i * 80 )
 					.onComplete(function(){
@@ -93,7 +94,7 @@ VRHud.prototype.show = function() {
 				mesh.scale.set(mesh.userData.scale.x * 0.75, mesh.userData.scale.y * 0.75, mesh.userData.scale.z);
 
 				var tween = new TWEEN.Tween( mesh.scale )
-					.to({ x: mesh.userData.scale.x, y: mesh.userData.scale.y, z: mesh.userData.scale.z}, 500 )
+					.to( { x: mesh.userData.scale.x, y: mesh.userData.scale.y, z: mesh.userData.scale.z} , 500 )
 					.easing(TWEEN.Easing.Exponential.Out)
 					.delay( i * 80 )
 					.start();
@@ -101,7 +102,7 @@ VRHud.prototype.show = function() {
 				mesh.material.opacity = 0;
 
 				var tween = new TWEEN.Tween( mesh.material )
-					.to({ opacity: 1}, 300 )
+					.to({ opacity: 1 }, 300 )
 					.easing(TWEEN.Easing.Exponential.Out)
 					.delay( i * 80 )
 					.start();

--- a/js/vrhud.js
+++ b/js/vrhud.js
@@ -52,6 +52,8 @@ function VRHud() {
 
 		self.makeLayout.call(self, meshNodes);
 		self.attachEvents.call(self, favorites);
+
+		self.show();
 	});
 
 	return this;
@@ -119,10 +121,21 @@ VRHud.prototype.show = function() {
 	});
 };
 
-VRHud.prototype.hide = function() {
+VRHud.prototype.hide = function(instantaneous) {
+	instantaneous === undefined && (instantaneous = false
+	);
 	var self = this;
 	return new Promise( function(resolve, reject) {
 		if (self.visible) {
+
+			var onComplete =  function() {
+				self.layout.visible = false;
+				self.visible = false;
+				resolve();
+			};
+
+			if (instantaneous) return onComplete();
+
 			var nodes = self.d23.getNodesByClass('fav');
 
 			nodes.reverse();
@@ -139,11 +152,7 @@ VRHud.prototype.hide = function() {
 					.to({ opacity: 0 }, 500 )
 					.easing(TWEEN.Easing.Exponential.Out)
 					.delay( i * 80 )
-					.onComplete(function() {
-						self.layout.visible = false;
-						self.visible = false;
-						resolve();
-					})
+					.onComplete(onComplete) // potential bug - hides on first mesh finished easing
 					.start();
 			}
 

--- a/js/vrhud.js
+++ b/js/vrhud.js
@@ -212,8 +212,9 @@ VRHud.prototype.attachEvents = function(favorites) {
 }
 
 VRHud.prototype.makeLayout = function(nodes) {
+	var hudScale = 0.15;
 	var self = this;
-	var hudRadius = 2;
+	var hudRadius = 2 * hudScale;
 
 	var layout = self.layout;
 
@@ -227,7 +228,9 @@ VRHud.prototype.makeLayout = function(nodes) {
 
 			var holder = new THREE.Object3D();
 
-			holder.positionRadially( hudRadius, mesh.position.x / hudRadius );
+			mesh.scale.multiplyScalar(0.5 * hudScale);
+			mesh.position.multiplyScalar(0.5 * hudScale);
+			holder.positionRadially( hudRadius, mesh.position.x / hudRadius, mesh.position.y );
 			mesh.position.set(0,0,0);  // Remove initial positioning from d23
 
 			mesh.geometry.bend( hudRadius, mesh );

--- a/js/vrhud.js
+++ b/js/vrhud.js
@@ -220,16 +220,14 @@ VRHud.prototype.makeLayout = function(nodes) {
 
 	this.favorites = [];
 
-	layout.position.set(0, -0.15, 0);
-
 	return new Promise( function(resolve, reject) {
 		nodes.forEach( function(node) {
 			var mesh = node.mesh;
 
 			var holder = new THREE.Object3D();
 
-			mesh.scale.multiplyScalar(0.5 * hudScale);
-			mesh.position.multiplyScalar(0.5 * hudScale);
+			mesh.scale.multiplyScalar(hudScale);
+			mesh.position.multiplyScalar(hudScale);
 			holder.positionRadially( hudRadius, mesh.position.x / hudRadius, mesh.position.y );
 			mesh.position.set(0,0,0);  // Remove initial positioning from d23
 
@@ -245,7 +243,8 @@ VRHud.prototype.makeLayout = function(nodes) {
 
 			if (Leap.loopController){
 				mesh.userData.button = new PushButton(
-					new InteractablePlane( mesh, Leap.loopController, {moveX: false, moveY: false} )
+					new InteractablePlane( mesh, Leap.loopController, {moveX: false, moveY: false} ),
+					{ locking: false }
 				);
 			}
 

--- a/js/vrhud.js
+++ b/js/vrhud.js
@@ -333,7 +333,7 @@ VRHud.prototype.makeLayout = function(nodes) {
 			mesh.position.set(0,0,0);  // Remove initial positioning from d23
 			mesh.scale.z = 1; // Remove initial z scaling, which ensures that buttons get pushed correctly w/o flicker.
 
-			mesh.geometry.bend( hudRadius, mesh );
+			mesh.bend( hudRadius );
 
 			holder.add( mesh );
 			layout.add( holder );

--- a/js/vrhud.js
+++ b/js/vrhud.js
@@ -145,6 +145,8 @@ VRHud.prototype.hide = function() {
 					})
 					.start();
 			}
+
+
 		} else {
 			// already hidden, so resolve.
 			resolve();
@@ -218,8 +220,12 @@ VRHud.prototype.attachEvents = function(favorites) {
 			mesh.receiveShadow = true;
 
 			button.on('press', function(){
+
+				if ( !self.visible ) return;
+
 				mesh.dispatchEvent({type: 'click'});
-			});
+
+			} );
 		}
 
 

--- a/js/vrhud.js
+++ b/js/vrhud.js
@@ -222,11 +222,16 @@ VRHud.prototype.makeLayout = function(nodes) {
 			var mesh = node.mesh;
 			// persist the current position so we can use it later.
 			mesh.userData.position = new THREE.Vector3(mesh.position.x, mesh.position.y, mesh.position.z);
-			console.log('adding mesh', mesh.name, mesh.position);
 			// here turn these in to interactable planes/buttons
 			// make them initially uninteractable
 
-			mesh.userData.scale = new THREE.Vector3(mesh.scale.x, mesh.scale.y, mesh.scale.z);
+			if (Leap.loopController){
+				mesh.userData.button = new PushButton(
+					new InteractablePlane(mesh, Leap.loopController)
+				);
+			}
+
+			// camera is available here window.VRManager.ui.camera
 
 			layout.add( mesh );
 		});

--- a/js/vrhud.js
+++ b/js/vrhud.js
@@ -260,7 +260,8 @@ VRHud.prototype.attachEvents = function(favorites) {
 				// scale = (base - travel) / base
 				// scale = 1 - travel / base
 
-				box.scale.z = ( 1 - mesh.position.z / button.options.longThrow );  // divide by 0 could be fun
+				box.scale.z = ( 1 - mesh.position.z / button.options.longThrow );
+				if (box.scale.z === 0) box.scale.z = 1e-7; // Prevent matrix inverse warning on 0-scale.
 
 				box.position.z = (button.options.longThrow + mesh.position.z) / 2;
 

--- a/js/vrmanager.js
+++ b/js/vrmanager.js
@@ -159,7 +159,7 @@ window.VRManager = (function() {
 
     newTab.loaded.then(function(){
 
-      if ( !self.ui.hud.visible ){
+      if ( !self.ui.hud.visible && self.currentDemo ){
         self.currentDemo.focus();
       }
 

--- a/js/vrmanager.js
+++ b/js/vrmanager.js
@@ -157,7 +157,16 @@ window.VRManager = (function() {
       }
     });
 
+    newTab.loaded.then(function(){
+
+      if ( !self.ui.hud.visible ){
+        self.currentDemo.focus();
+      }
+
+    });
+
     newTab.load();
+
   };
 
   /*

--- a/js/vrtab.js
+++ b/js/vrtab.js
@@ -164,5 +164,5 @@ VRTab.prototype.onWindowResize = function () {
   // This triggers the resize event within the iframe when the parent window resizes
   var iframe = this.iframe;
   iframe.height = window.innerHeight;
-  iframe.height = window.innerWidth;
+  iframe.width  = window.innerWidth;
 };

--- a/js/vrtitle.js
+++ b/js/vrtitle.js
@@ -17,6 +17,8 @@ function VRTitle() {
 				var node = d23.getNodeById('current', true);
 				var mesh = node.mesh;
 
+				mesh.scale.multiplyScalar(0.25);
+
 				mesh.visible = self.visible;
 
 				self.mesh = mesh;

--- a/js/vrui.js
+++ b/js/vrui.js
@@ -365,7 +365,7 @@ VRUi.prototype.initRenderer = function() {
 	this.renderer = new THREE.WebGLRenderer({ alpha: true });
 	this.renderer.sortObjects = false;
 	this.renderer.shadowMapEnabled = true;
-	//this.renderer.shadowMapType = THREE.PCFSoftShadowMap;
+	this.renderer.shadowMapType = THREE.PCFSoftShadowMap;
   this.renderer.setClearColor( 0x000000, 0 );
   this.scene = new THREE.Scene();
   this.camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.01, 10000 );
@@ -391,8 +391,21 @@ VRUi.prototype.initRenderer = function() {
 // But before animate (#start), so that the Leap animation frame callbacks get registered before the render ones.
 VRUi.prototype.initLeapInteraction = function() {
 
-	Leap.loop() // more for dev - makes use while consoling easier
-		.use('transform', {
+	Leap.loop(); // more for dev - makes use while consoling easier
+
+	// Add a certain default lightness, even in low-light situations
+	Leap.loopController.on('handMeshCreated', function(handMesh){
+
+		handMesh.traverse(function(mesh){
+			// mesh is a joint or a bone
+			if (mesh.material){
+				mesh.material.emissive.copy(mesh.material.color).multiplyScalar(0.75);
+			}
+		})
+
+	});
+
+	Leap.loopController.use('transform', {
 			vr: true,
 			effectiveParent: this.camera
 		})
@@ -405,6 +418,7 @@ VRUi.prototype.initLeapInteraction = function() {
 
 	// Set initial Leap focus state. See LeapJS's browser.js L64
 	Leap.loopController.connection.windowVisible = this.hud.visible && this.hud.enabled;
+
 
 
 	var light = new THREE.SpotLight(0xffffff, 0.25);

--- a/js/vrui.js
+++ b/js/vrui.js
@@ -27,7 +27,7 @@ function VRUi(container) {
 
 	this.initRenderer();
 
-	//this.initLeapInteraction();
+	this.initLeapInteraction();
 
 	//self.scene.add(self.gridlines());
 
@@ -259,9 +259,8 @@ THREE.PlaneGeometry.prototype.bend = function(radius, mesh ){
 			worldVertex.y,
 			- Math.cos( worldVertex.x / radius ) * radius
 		)
-
-		mesh.worldToLocal(vertex);
 		vertex.z += radius;
+		mesh.worldToLocal(vertex);
 	}
 
 	this.computeBoundingSphere();

--- a/js/vrui.js
+++ b/js/vrui.js
@@ -62,6 +62,9 @@ function VRUi(container) {
 			self.scene.add(self.cursor.layout);
 
 			self.cursor.init(self.renderer.domElement, self.camera, self.hud.layout);
+			self.cursor.enable();
+			self.cursor.cursor.position.z = -0.22;
+			self.cursor.cursor.scale.multiplyScalar(0.2);
 
 			// Once all this is loaded, kick off start from VR
 			// self.start();
@@ -427,11 +430,9 @@ VRUi.prototype.initLeapInteraction = function() {
 
 	Leap.loopController.setMaxListeners(100);  // Don't overload with many interactable planes
 
-	Leap.loopController.on('streamingStarted', function(){
 
-		this.updateCursorState();
-
-	}.bind(this) );
+	Leap.loopController.on('streamingStarted', this.updateCursorState.bind(this) );
+	Leap.loopController.on('streamingStopped', this.updateCursorState.bind(this) );
 
 	// Set initial Leap focus state. See LeapJS's browser.js L64
 	Leap.loopController.connection.windowVisible = this.hud.visible && this.hud.enabled;

--- a/js/vrui.js
+++ b/js/vrui.js
@@ -371,7 +371,7 @@ VRUi.prototype.initRenderer = function() {
 
 	if (THREE.OrbitControls) window.orbitControls = new THREE.OrbitControls( this.camera );
 	//if (THREE.OrbitControls) this.camera.position.set( 0, 0, 0.1 );
-	if (THREE.OrbitControls) this.camera.position.set( 2.3831, 13.825, 6.1769 );
+	if (THREE.OrbitControls) this.camera.position.set( 2.3, 13.8, 6.2).divideScalar(16);
 	if (THREE.OrbitControls) this.camera.rotation.set( -1.1506, 0.15609, 0.3348 );
 
 	this.setRenderMode(this.mode);
@@ -512,7 +512,7 @@ VRUi.prototype.animate = function() {
 	var controls = this.controls;
 
 	// apply headset orientation and position to camera
-	if (controls) {
+	if (controls && !THREE.OrbitControls) {
 		this.controls.update();
 	}
 

--- a/js/vrui.js
+++ b/js/vrui.js
@@ -27,7 +27,7 @@ function VRUi(container) {
 
 	this.initRenderer();
 
-	this.initLeapInteraction();
+	//this.initLeapInteraction();
 
 	//self.scene.add(self.gridlines());
 

--- a/js/vrui.js
+++ b/js/vrui.js
@@ -449,7 +449,7 @@ VRUi.prototype.initLeapInteraction = function() {
 
 			if (!this.hud.visible){
 
-				this.hud.show();
+				this.toggleHud();
 				this.hud.leapActivated = true;
 
 			}
@@ -460,7 +460,7 @@ VRUi.prototype.initLeapInteraction = function() {
 
 			if ( this.hud.visible && this.hud.leapActivated ) {
 
-				this.hud.hide();
+				this.toggleHud();
 
 			}
 

--- a/js/vrui.js
+++ b/js/vrui.js
@@ -425,6 +425,7 @@ VRUi.prototype.initLeapInteraction = function() {
 			if (!this.hud.visible){
 
 				this.hud.show();
+				this.hud.leapActivated = true;
 
 			}
 
@@ -432,7 +433,7 @@ VRUi.prototype.initLeapInteraction = function() {
 
 		if ( frame.hands.length === 0 ) {
 
-			if (this.hud.visible) {
+			if ( this.hud.visible && this.hud.leapActivated ) {
 
 				this.hud.hide();
 

--- a/js/vrui.js
+++ b/js/vrui.js
@@ -27,6 +27,9 @@ function VRUi(container) {
 
 	this.initRenderer();
 
+	// This needs to be called before init leap, so that it can stop events before they get picked up and sent to the Leap Service
+	this.rerouteFocusEvents();
+
 	this.initLeapInteraction();
 
 	//self.scene.add(self.gridlines());
@@ -150,6 +153,27 @@ VRUi.prototype.load = function(url, opts) {
 		});
 };
 
+// This function, somewhat experimentally, allows only one context to have focus state at a time (either the iframe, or the hud)
+VRUi.prototype.rerouteFocusEvents = function(){
+
+	window.addEventListener('focus', function(e) {
+		if ( !( this.hud.visible && this.hud.enabled ) ) {
+			e.stopImmediatePropagation();
+			VRManager.currentDemo.focus();
+		}
+		return false;
+	}.bind(this) );
+
+	window.addEventListener('blur', function(e) {
+		if ( !( this.hud.visible && this.hud.enabled ) ) {
+			e.stopImmediatePropagation();
+			VRManager.currentDemo.blur();
+		}
+		return false;
+	}.bind(this) );
+
+}
+
 
 VRUi.prototype.toggleHud = function() {
 	if (!this.hud.visible && this.hud.enabled) {
@@ -162,6 +186,7 @@ VRUi.prototype.toggleHud = function() {
 		this.cursor.enable();
 		this.cursor.show();
 		VRManager.currentDemo.blur();
+		window.dispatchEvent(new Event('focus'));
 
 
 	} else if (this.hud.visible && this.hud.enabled) {
@@ -172,6 +197,7 @@ VRUi.prototype.toggleHud = function() {
 		this.title.hide(1000);
 		this.cursor.disable();
 		VRManager.currentDemo.focus();
+		window.dispatchEvent(new Event('blur'));
 
 	} else {
 		this.hud.hide();
@@ -376,6 +402,9 @@ VRUi.prototype.initLeapInteraction = function() {
 		});
 
 	Leap.loopController.setMaxListeners(100);  // Don't overload with many interactable planes
+
+	// Set initial Leap focus state. See LeapJS's browser.js L64
+	Leap.loopController.connection.windowVisible = this.hud.visible && this.hud.enabled;
 
 
 	var light = new THREE.SpotLight(0xffffff, 0.25);

--- a/js/vrui.js
+++ b/js/vrui.js
@@ -44,8 +44,14 @@ function VRUi(container) {
 			self.scene.add(self.transition.object);
 
 			// title
-			self.bend(self.title.mesh, 2.5, true)
 			self.scene.add(self.title.mesh);
+			var titleRadius = 0.4;
+
+			// Bending one seems to bend them all -.-
+			setTimeout(function(){ // This quick setTimeout hack seems to fix tile bending weirdly/parabolically
+				self.title.mesh.children[0].bend( titleRadius );
+				self.title.mesh.positionRadially( titleRadius, 0, 0 );
+			});
 
 			self.scene.add(self.hud.layout);
 
@@ -267,28 +273,26 @@ THREE.Object3D.prototype.positionRadially = function(radius, angle, height){
 };
 
 
-THREE.PlaneGeometry.prototype.bend = function(radius, mesh ){
-	var vertices = this.vertices;
-	mesh.updateMatrixWorld();
+THREE.Object3D.prototype.bend = function(radius ){
+	var geometry = this.geometry;
+	var vertices = geometry.vertices;
+	this.updateMatrixWorld();
 
 	for (var i = 0; i < vertices.length; i++) {
 		var vertex = vertices[i];
-		var worldVertex = mesh.localToWorld(vertex);
-
-		//vertex.x = Math.sin( vertex.x / radius) * radius;
-		//vertex.z = - Math.cos( vertex.x / radius ) * radius;
+		var worldVertex = this.localToWorld(vertex);
 
 		vertex.set(
 			Math.sin( worldVertex.x / radius) * radius,
 			worldVertex.y,
 			- Math.cos( worldVertex.x / radius ) * radius
-		)
+		);
 		vertex.z += radius;
-		mesh.worldToLocal(vertex);
+		this.worldToLocal(vertex);
 	}
 
-	this.computeBoundingSphere();
-	this.verticesNeedUpdate = true;
+	geometry.computeBoundingSphere();
+	geometry.verticesNeedUpdate = true;
 }
 
 

--- a/js/vrui.js
+++ b/js/vrui.js
@@ -84,42 +84,38 @@ VRUi.prototype.load = function(url, opts) {
 
 	self.cursor.disable();
 
-				.then(function() {
 	self.transition.fadeOut(noTransition)
 		.then(function() {
 
+			self.backgroundShow();
 
-					self.title.setTitle('');
 			// set title URL
 			self.title.setTitle('');
 			self.title.setCredits('');
 			self.title.setUrl(url);
 
-						self.backgroundHide();
 			if (noTitle) {
 				self.backgroundHide();
 			} else {
 				self.title.show();
 			}
 
+			self.currentUrl = url;
 
+			self.isHome = (url == self.homeUrl ? true : false );
 
-						self.hud.enable();
 			if (self.isHome) {
 				self.hud.enable();
 			}
 
-						self.loading.show();
 			if (!noLoading) {
 				self.loading.show();
 			}
 
-						var title = tab.siteInfo.title;
 			function onPageMeta(tab) {
 				var title = tab.siteInfo.title;
 				var credits = tab.siteInfo.description;
 
-							self.title.setTitle(title);
 				if (title) {
 					self.title.setTitle(title);
 				}
@@ -128,30 +124,29 @@ VRUi.prototype.load = function(url, opts) {
 				}
 			}
 
-						var holdTitleTime = 5000; // how long to hold title for before fading out.
 			function onTabReady() {
 				var holdTitleTime = 5000; // how long to hold title for before fading out.
 
+				self.backgroundHide(holdTitleTime);
 
+				self.loading.hide();
 
+				self.transition.fadeIn();
 
-						setTimeout(function() {
 				// hide title after set amount of time
 				setTimeout(function() {
 					if (!self.hud.visible) {
 						self.title.hide();
 					}
 				}, holdTitleTime);
+			}
 
 			VRManager.onPageMeta = onPageMeta;
 
-					VRManager.onTabReady = onTabReady;
 			VRManager.onTabReady = onTabReady;
 
-					VRManager.load(url);
 			VRManager.load(url);
 
-				});
 			//VRManager.currentDemo.focus();
 
 		});


### PR DESCRIPTION
This allows icons to be pushed for users with the Leap Motion plugged in.

It is a progressive enhancement - behavior for non Leap Motion users almost unchanged.

The construct scaling has been altered, with the icons now showing up at a distance of about 40cm, instead of the 5-7m they were at before.

![screenshot 2014-12-01 23 47 31](https://cloud.githubusercontent.com/assets/407497/5272962/0b3b6238-7a37-11e4-8f23-4b3972052e59.png)

http://leapmotion.github.io/HIRO/

Current direction, looking for feedback.  Not sure if these are blockers or not.
 - Make the buttons less jumpy
 - Add manipulation to the back buttons in construct, and then the HUD
 - Explore improving the shadows below the icons, so that they illustrate depth truly.