### PR TITLE
add placeholder file for Twitter API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-appKeys/*
+appKeys/*.js
 content/*
 **/test/*
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Hiro is the code that drives [MozVR.com](http://mozvr.com), a "VR website about VR websites" from Mozilla Research.
 
+
+## Development
+
 To hack on the HIRO source go to your command line:
 
 * `git clone https://github.com/MozVR/HIRO.git`
@@ -10,6 +13,21 @@ To hack on the HIRO source go to your command line:
 * Open [http://localhost:8080](http://localhost:8080) in your browser
 
 fork and clone the repo then run `npm install` in the command line utility of your preference from your new local HIRO directory.
+
+### Twitter API Keys
+
+A Twitter "tweet cloud" is created in the [`express` Gulp task](gulpfile.js), which requires Twitter API keys. Follow these steps to make that work locally:
+
+1. Register your app at https://apps.twitter.com/app/new
+2. Load [https://apps.twitter.com/app/`<app_id>`/keys](https://apps.twitter.com/app/<app_id>/keys)
+3. Take note of the "Consumer Key" and "Consumer Secret" in the "Application Settings" section.
+4. Scroll to the "Your Access Token" and press the "Create my access token" button.
+5. Create the file for the Twitter API keys (copied from `twitter.js.dist`):
+
+        cp appKeys/twitter.js{.dist,}
+
+6. Open the `appKeys/twitter.js` file and fill in the blanks.
+
 
 ## Credits
 

--- a/appKeys/twitter.js.dist
+++ b/appKeys/twitter.js.dist
@@ -1,0 +1,10 @@
+// Register your Twitter application here: https://apps.twitter.com/app/new
+
+module.exports.getKeys = function () {
+  return {
+    consumer_key: '',
+    consumer_secret: '',
+    access_token: '',
+    access_token_secret: ''
+  };
+};


### PR DESCRIPTION
I encountered this error after running `npm install`:

```
[14:07:54] Error: Cannot find module './appKeys/twitter'
```

![screenshot 2015-03-08 14 58 07](https://cloud.githubusercontent.com/assets/203725/6548141/9be30348-c5ac-11e4-8d36-f03320784042.png)
